### PR TITLE
mobile header: show the pagename at the center #385

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.131.0",
+	"version": "0.132.0",
 	"type": "module",
 	"packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",
 	"scripts": {

--- a/prompts/agent-rules.md
+++ b/prompts/agent-rules.md
@@ -11,12 +11,13 @@
 
 Whenever modifying, adding, or deleting any code:
 
-1. **Verify Type Safety**: Run `pnpm run check`.
-2. **Verify Style and Quality**: Run `pnpm run lint`.
-3. **Verify IDE Feedback**: ALWAYS review the "IDE feedback" provided in the prompt for any remaining lint errors. This is usually more up-to-date than terminal commands.
-4. **Fix Issues**: If any check fails (terminal or IDE feedback), fix all reported issues immediately.
-5. **Repeat**: Repeat the checks until they pass.
-6. **Completion**: Only finish the task or response after ALL checks pass.
+1. **Refactor First**: Before submitting, apply refactoring (high and medium priority) to all newly written or modified code. Follow the instructions in `prompts/refactoring.md`.
+2. **Verify Type Safety**: Run `pnpm run check`.
+3. **Verify Style and Quality**: Run `pnpm run lint`.
+4. **Verify IDE Feedback**: ALWAYS review the "IDE feedback" provided in the prompt for any remaining lint errors. This is usually more up-to-date than terminal commands.
+5. **Fix Issues**: If any check fails (terminal or IDE feedback), fix all reported issues immediately.
+6. **Repeat**: Repeat the checks until they pass.
+7. **Completion**: Only finish the task or response after ALL checks pass.
 
 **Constraint**: Never state "it should pass" without actually having run the commands and confirmed the output. Do not end a task while errors exist. If verification commands fail (e.g., system error), you MUST rely on IDE feedback to ensure correctness.
 

--- a/src/app.css
+++ b/src/app.css
@@ -140,6 +140,8 @@ code {
 
 .cyber-glow-hover * {
 	transition:
+		opacity 0.3s ease-out,
+		max-width 0.3s ease-out,
 		color 0.3s ease-out,
 		fill 0.3s ease-out,
 		filter 0.3s ease-out,

--- a/src/lib/components/HeaderLogoLink.svelte
+++ b/src/lib/components/HeaderLogoLink.svelte
@@ -2,7 +2,14 @@
 	import { resolve } from '$app/paths'
 	import { AUTHOR } from '$lib/app'
 	import LogoWithGlow from '$lib/components/LogoWithGlow.svelte'
-	import { HEADER_ICON_SIZE, HEADER_LOGO_GLOW_CLASS } from '$lib/constants/sticky-header-constants'
+	import {
+		HEADER_ICON_SIZE,
+		HEADER_LOGO_GLOW_CLASS,
+		HEADER_LOGO_TEXT_HIDDEN,
+		HEADER_LOGO_TEXT_VISIBLE,
+	} from '$lib/constants/sticky-header-constants'
+
+	const { is_text_hidden = false }: { is_text_hidden?: boolean } = $props()
 </script>
 
 <a
@@ -12,7 +19,9 @@
 >
 	<LogoWithGlow size={HEADER_ICON_SIZE} />
 	<span
-		class="text-xl font-medium tracking-tight text-white/90 {HEADER_LOGO_GLOW_CLASS} group-hover:text-white"
+		class="overflow-hidden text-xl font-medium tracking-tight whitespace-nowrap text-white/90 {HEADER_LOGO_GLOW_CLASS} group-hover:text-white {is_text_hidden
+			? HEADER_LOGO_TEXT_HIDDEN
+			: HEADER_LOGO_TEXT_VISIBLE}"
 	>
 		{AUTHOR.NAME}
 	</span>

--- a/src/lib/components/HeaderPageLinkContent.svelte
+++ b/src/lib/components/HeaderPageLinkContent.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { NAV_ICON_SIZE } from '$lib/constants/sticky-header-constants'
+	import { MENU_NAV_ICON_DESKTOP, NAV_ICON_SIZE } from '$lib/constants/sticky-header-constants'
 	import type { Page } from '$lib/types/page'
 
 	const { page } = $props<{ page: Page }>()
@@ -8,6 +8,6 @@
 {#if page.icon}
 	<!-- eslint-disable-next-line @typescript-eslint/naming-convention -->
 	{@const PageIcon = page.icon}
-	<PageIcon size={NAV_ICON_SIZE} />
+	<PageIcon size={NAV_ICON_SIZE} class={MENU_NAV_ICON_DESKTOP} />
 {/if}
 {page.title}

--- a/src/lib/components/PageHeader.svelte
+++ b/src/lib/components/PageHeader.svelte
@@ -1,14 +1,39 @@
 <script lang="ts">
 	import { ICON_SIZE_XL } from '$lib/constants/layout'
+	import { HEADER_HEIGHT_PX } from '$lib/constants/sticky-header-constants'
+	import { page_title_visibility_state } from '$lib/hooks/PageTitleVisibilityState.svelte'
 	import LogoIcon from '$lib/icons/LogoIcon.svelte'
 	import { PAGES, type Page } from '$lib/types/page'
 
 	const { page } = $props<{ page: Page }>()
 	const { icon, title, description } = $derived(page)
 	const is_top_page = $derived(page === PAGES.TOP)
+
+	function observe_visibility(element: HTMLElement): { destroy: () => void } {
+		let is_previous_visible: boolean | undefined = undefined
+
+		function update(): void {
+			const is_visible = element.getBoundingClientRect().bottom > HEADER_HEIGHT_PX
+			if (is_visible === is_previous_visible) return
+			is_previous_visible = is_visible
+			page_title_visibility_state.set_visible(is_visible)
+		}
+
+		update()
+		window.addEventListener('scroll', update, { passive: true })
+
+		return {
+			destroy() {
+				window.removeEventListener('scroll', update)
+			},
+		}
+	}
 </script>
 
-<header class="mb-4 flex flex-col items-center justify-center {is_top_page ? '' : 'mt-6'}">
+<header
+	use:observe_visibility
+	class="mb-4 flex flex-col items-center justify-center {is_top_page ? '' : 'mt-6'}"
+>
 	{#if is_top_page}
 		<div class="my-4">
 			<LogoIcon />

--- a/src/lib/components/StickyHeader.svelte
+++ b/src/lib/components/StickyHeader.svelte
@@ -8,22 +8,27 @@
 	import StickyHeaderOverlay from '$lib/components/StickyHeaderOverlay.svelte'
 	import {
 		HEADER_CONTAINER_CLASSES,
+		HEADER_FADE_DURATION_MS,
 		HEADER_LEFT_SECTION_CLASSES,
 		HEADER_RIGHT_SECTION_CLASSES,
 		MENU_TOGGLE_BUTTON_CLASSES,
 		NAV_ICON_SIZE,
 	} from '$lib/constants/sticky-header-constants'
+	import { page_title_visibility_state } from '$lib/hooks/PageTitleVisibilityState.svelte'
 	import { sticky_header_state } from '$lib/hooks/StickyHeaderState.svelte'
 	import CloseIcon from '$lib/icons/CloseIcon.svelte'
 	import MenuIcon from '$lib/icons/MenuIcon.svelte'
 	import { link_utilities } from '$lib/utils/link-utilities'
 	import { page_title } from '$lib/utils/page-title'
 	import { sticky_header_menu } from '$lib/utils/sticky-header-menu'
+	import { fade } from 'svelte/transition'
 
 	const is_menu_open = $derived(sticky_header_state.get_is_menu_open())
 
 	const current_page = $derived(page_title.get_page_from_path(page.url.pathname))
 	const is_top_page = $derived(page.url.pathname === '/')
+	const is_page_title_visible = $derived(page_title_visibility_state.get_is_visible())
+	const is_showing_page_link = $derived(!is_top_page && !is_page_title_visible)
 
 	const link_info = $derived(link_utilities.get_link_info(current_page.link))
 
@@ -32,11 +37,15 @@
 
 <header class={HEADER_CONTAINER_CLASSES}>
 	<div class={HEADER_LEFT_SECTION_CLASSES}>
-		<HeaderLogoLink />
+		<HeaderLogoLink is_text_hidden={is_showing_page_link} />
 
-		{#if !is_top_page}
-			<span class="invisible shrink-0 text-white/40 md:hidden" aria-hidden="true">|</span>
-			<HeaderPageLink page={current_page} href={link_info.href} is_link={link_info.is_link} />
+		{#if is_showing_page_link}
+			<div
+				class="absolute left-1/2 -translate-x-1/2 md:hidden"
+				transition:fade={{ duration: HEADER_FADE_DURATION_MS }}
+			>
+				<HeaderPageLink page={current_page} href={link_info.href} is_link={link_info.is_link} />
+			</div>
 		{/if}
 
 		<nav class="hidden items-center gap-2 md:flex" aria-label="ページナビゲーション">

--- a/src/lib/constants/sticky-header-constants.ts
+++ b/src/lib/constants/sticky-header-constants.ts
@@ -1,11 +1,13 @@
 const MENU_WIDTH = 280
 const HEADER_ICON_SIZE = 24
+const HEADER_FADE_DURATION_MS = 300
 
 const HEADER_CONTAINER_CLASSES =
 	'fixed top-0 right-0 left-0 z-50 flex h-16 items-center justify-between border-b border-white/5 bg-slate-950/70 px-6 backdrop-blur-md transition-all duration-500'
 const HEADER_LEFT_SECTION_CLASSES = 'flex min-w-0 flex-1 items-center gap-4 md:gap-6'
 const HEADER_RIGHT_SECTION_CLASSES = 'flex shrink-0 items-center gap-2'
 const HEADER_HEIGHT = '4rem'
+const HEADER_HEIGHT_PX = 64
 const NAV_ICON_SIZE = '1.25rem'
 
 const MENU_NAV_DESKTOP_BASE =
@@ -37,8 +39,11 @@ const SOCIAL_LINK_CONTAINER_DESKTOP = 'hidden items-center gap-2 md:flex'
 const SOCIAL_LINK_CONTAINER_MOBILE = 'mt-4 flex gap-2 p-4 pt-0 md:hidden'
 
 const HEADER_PAGE_LINK_BASE =
-	'flex shrink-0 items-center gap-2 truncate text-base font-medium text-white/80 md:hidden [&_svg]:text-inherit'
+	'group flex min-w-0 items-center gap-2 text-base font-medium text-white/80 md:hidden [&_svg]:text-inherit'
 const HEADER_PAGE_LINK_ACTIVE = `cyber-glow-hover rounded-lg px-2 py-1 ${HEADER_PAGE_LINK_BASE} hover:text-white hover:[&_svg]:text-white`
+
+const HEADER_LOGO_TEXT_VISIBLE = 'max-w-xs opacity-100'
+const HEADER_LOGO_TEXT_HIDDEN = 'max-w-0 opacity-0 md:max-w-xs md:opacity-100'
 
 const MENU_DRAWER_CLASSES =
 	'fixed right-0 z-50 h-full overflow-y-auto border-l border-white/5 bg-slate-950/70 shadow-2xl backdrop-blur-md transition-transform duration-300 ease-in-out'
@@ -48,10 +53,14 @@ type StickyHeaderVariant = 'desktop' | 'mobile'
 export type { StickyHeaderVariant }
 export {
 	HEADER_CONTAINER_CLASSES,
+	HEADER_FADE_DURATION_MS,
 	HEADER_HEIGHT,
+	HEADER_HEIGHT_PX,
 	HEADER_ICON_SIZE,
 	HEADER_LEFT_SECTION_CLASSES,
 	HEADER_LOGO_GLOW_CLASS,
+	HEADER_LOGO_TEXT_VISIBLE,
+	HEADER_LOGO_TEXT_HIDDEN,
 	HEADER_PAGE_LINK_ACTIVE,
 	HEADER_PAGE_LINK_BASE,
 	HEADER_RIGHT_SECTION_CLASSES,

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -91,7 +91,7 @@ export const PROJECTS: Array<Project> = [
 			{ href: `${URLS.GITHUB}/tic-tac-toe`, type: 'github' },
 		],
 		image: tic_tac_toe,
-		tags: [GODOT, GDSCRIPT, 'GL Compatibility', WEB_EXPORT],
+		tags: [GODOT, GDSCRIPT, WEB_EXPORT],
 	},
 	{
 		icon: TennisIcon,

--- a/src/lib/data/tech-colors.ts
+++ b/src/lib/data/tech-colors.ts
@@ -21,7 +21,6 @@ const TECH_COLOR_ENTRIES = [
 	['Godot / GDScript', '#478cbf'],
 	['GDShader', '#7c3aed'],
 	['GDUnit4', '#478cbf'],
-	['GL Compatibility', '#10b981'],
 	['Web Export', '#6366f1'],
 	['WebSockets', '#22c55e'],
 	['WebSocket', '#22c55e'],

--- a/src/lib/hooks/PageTitleVisibilityState.svelte.ts
+++ b/src/lib/hooks/PageTitleVisibilityState.svelte.ts
@@ -1,0 +1,16 @@
+let is_page_title_visible = $state(true)
+
+function get_is_visible(): boolean {
+	return is_page_title_visible
+}
+
+function set_visible(visible: boolean): void {
+	is_page_title_visible = visible
+}
+
+const page_title_visibility_state = {
+	get_is_visible,
+	set_visible,
+}
+
+export { page_title_visibility_state }


### PR DESCRIPTION
closes #385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ページタイトルのスクロール位置に基づいてヘッダーが動的に表示・非表示になります
  * ヘッダーロゴテキストの表示制御機能を追加しました

* **改善**
  * ヘッダーの表示・非表示時にフェード遷移アニメーションを実装しました
  * 要素のアニメーションエフェクトを強化し、より滑らかな動作を実現しました

* **その他**
  * バージョンを 0.131.0 から 0.132.0 にアップデートしました
  * プロジェクトデータをクリーンアップしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->