### PR TITLE
feat: add /contact page with spam-protected email and social links

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -35,6 +35,7 @@ words:
   - Hotspots
   - inlang
   - Mcpjson
+  - networkidle
   - reassignable
   - amazonwebservices
   - androidstudio

--- a/e2e/contact.test.ts
+++ b/e2e/contact.test.ts
@@ -62,6 +62,7 @@ test.describe('Contact page', () => {
 
 	test('reveals the email address and mailto link after clicking reveal', async ({ page }) => {
 		await page.goto(CONTACT_PATH)
+		await page.waitForLoadState('networkidle')
 
 		await page.getByRole(BUTTON_ROLE, { name: REVEAL_BUTTON_NAME }).click()
 

--- a/e2e/contact.test.ts
+++ b/e2e/contact.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from '@playwright/test'
+
+const CONTACT_PATH = '/contact'
+const HOME_PATH = '/'
+
+const CONTACT_TITLE = 'Contact'
+const EMAIL_ADDRESS = 'joshuafolkken@gmail.com'
+
+const HEADING_ROLE = 'heading'
+const LINK_ROLE = 'link'
+const BUTTON_ROLE = 'button'
+
+const LEVEL_1 = 1
+const LEVEL_2 = 2
+
+const CONTACT_URL_PATTERN = /\/contact$/u
+const MAILTO_PATTERN = /^mailto:joshuafolkken@gmail\.com$/u
+
+const SOCIAL_HEADING = 'Connect on social'
+const REVEAL_BUTTON_NAME = /Reveal email address/u
+
+const X_HREF = 'https://x.com/joshuafolkken'
+const GITHUB_HREF = 'https://github.com/joshuafolkken'
+const YOUTUBE_HREF = 'https://www.youtube.com/@Joshuafolkken-studio'
+
+test.describe('Contact page', () => {
+	test('renders h1 Contact', async ({ page }) => {
+		await page.goto(CONTACT_PATH)
+
+		await expect(
+			page.getByRole(HEADING_ROLE, { level: LEVEL_1, name: CONTACT_TITLE }),
+		).toBeVisible()
+	})
+
+	test('lists social links in X, GitHub, YouTube order with expected URLs', async ({ page }) => {
+		await page.goto(CONTACT_PATH)
+
+		const social_heading = page.getByRole(HEADING_ROLE, {
+			level: LEVEL_2,
+			name: SOCIAL_HEADING,
+		})
+		const social_section = social_heading.locator('..')
+		const social_links = social_section.getByRole(LINK_ROLE)
+
+		await expect(social_links).toHaveCount(3)
+		await expect(social_links.nth(0)).toHaveAttribute('href', X_HREF)
+		await expect(social_links.nth(1)).toHaveAttribute('href', GITHUB_HREF)
+		await expect(social_links.nth(2)).toHaveAttribute('href', YOUTUBE_HREF)
+	})
+
+	test('does not leak the full email address in the initial HTML', async ({ page }) => {
+		await page.goto(CONTACT_PATH)
+
+		await expect(page.getByRole(BUTTON_ROLE, { name: REVEAL_BUTTON_NAME })).toBeVisible()
+
+		expect(await page.content()).not.toContain(EMAIL_ADDRESS)
+		expect(await page.content()).not.toContain('mailto:')
+	})
+
+	test('reveals the email address and mailto link after clicking reveal', async ({ page }) => {
+		await page.goto(CONTACT_PATH)
+
+		await page.getByRole(BUTTON_ROLE, { name: REVEAL_BUTTON_NAME }).click()
+
+		const mailto_link = page.getByRole(LINK_ROLE, { name: new RegExp(EMAIL_ADDRESS, 'u') })
+
+		await expect(mailto_link).toBeVisible()
+		await expect(mailto_link).toHaveAttribute('href', MAILTO_PATTERN)
+	})
+})
+
+test.describe('Footer Contact link', () => {
+	test('home footer shows a Contact link that navigates to /contact', async ({ page }) => {
+		await page.goto(HOME_PATH)
+
+		const contact_link = page.getByRole(LINK_ROLE, { name: CONTACT_TITLE }).first()
+
+		await expect(contact_link).toBeVisible()
+
+		await contact_link.click()
+
+		await expect(page).toHaveURL(CONTACT_URL_PATTERN)
+	})
+})

--- a/e2e/contact.test.ts
+++ b/e2e/contact.test.ts
@@ -72,7 +72,16 @@ test.describe('Contact page', () => {
 	})
 })
 
-test.describe('Reveal button hover icon', () => {
+test.describe('Reveal button hover affordance', () => {
+	test('uses a pointer cursor', async ({ page }) => {
+		await page.goto(CONTACT_PATH)
+
+		await expect(page.getByRole(BUTTON_ROLE, { name: REVEAL_BUTTON_NAME })).toHaveCSS(
+			'cursor',
+			'pointer',
+		)
+	})
+
 	test('swaps the icon on hover', async ({ page }) => {
 		await page.goto(CONTACT_PATH)
 

--- a/e2e/contact.test.ts
+++ b/e2e/contact.test.ts
@@ -19,6 +19,9 @@ const MAILTO_PATTERN = /^mailto:joshuafolkken@gmail\.com$/u
 const SOCIAL_HEADING = 'Connect on social'
 const REVEAL_BUTTON_NAME = /Reveal email address/u
 
+const ICON_DEFAULT_TESTID = 'contact-email-reveal-icon-default'
+const ICON_HOVER_TESTID = 'contact-email-reveal-icon-hover'
+
 const X_HREF = 'https://x.com/joshuafolkken'
 const GITHUB_HREF = 'https://github.com/joshuafolkken'
 const YOUTUBE_HREF = 'https://www.youtube.com/@Joshuafolkken-studio'
@@ -66,6 +69,23 @@ test.describe('Contact page', () => {
 
 		await expect(mailto_link).toBeVisible()
 		await expect(mailto_link).toHaveAttribute('href', MAILTO_PATTERN)
+	})
+})
+
+test.describe('Reveal button hover icon', () => {
+	test('swaps the icon on hover', async ({ page }) => {
+		await page.goto(CONTACT_PATH)
+
+		const default_icon = page.getByTestId(ICON_DEFAULT_TESTID)
+		const hover_icon = page.getByTestId(ICON_HOVER_TESTID)
+
+		await expect(default_icon).toBeVisible()
+		await expect(hover_icon).toBeHidden()
+
+		await page.getByRole(BUTTON_ROLE, { name: REVEAL_BUTTON_NAME }).hover()
+
+		await expect(default_icon).toBeHidden()
+		await expect(hover_icon).toBeVisible()
 	})
 })
 

--- a/e2e/legal-pages.test.ts
+++ b/e2e/legal-pages.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 
 const PRIVACY_PATH = '/privacy'
 const TERMS_PATH = '/terms'
@@ -7,6 +7,8 @@ const LEGACY_PRIVACY_PATH = '/privacy-policy'
 const PRIVACY_TITLE = 'Privacy Policy'
 const TERMS_TITLE = 'Terms of Service'
 const INTRODUCTION_HEADING = 'Introduction'
+const CONTACT_US_HEADING = 'Contact Us'
+const CONTACT_PAGE_LINK_NAME = 'Contact page'
 
 const HEADING_ROLE = 'heading'
 const LINK_ROLE = 'link'
@@ -17,8 +19,27 @@ const LEVEL_2 = 2
 const LAST_UPDATED_PATTERN = /Last Updated:/u
 const PRIVACY_URL_PATTERN = /\/privacy$/u
 const TERMS_URL_PATTERN = /\/terms$/u
+const CONTACT_URL_PATTERN = /\/contact$/u
+
+const PLAINTEXT_EMAIL = 'joshuafolkken@gmail.com'
 
 const RENDERS_H1_AND_LAST_UPDATED = 'renders h1 and Last Updated'
+const CONTACT_SECTION_TEST_NAME = 'Contact Us section links to /contact and hides plaintext email'
+
+async function assert_contact_us_cross_link(page: Page, path: string): Promise<void> {
+	await page.goto(path)
+
+	const contact_heading = page.getByRole(HEADING_ROLE, {
+		level: LEVEL_2,
+		name: CONTACT_US_HEADING,
+	})
+	const contact_section = contact_heading.locator('..')
+	const contact_link = contact_section.getByRole(LINK_ROLE, { name: CONTACT_PAGE_LINK_NAME })
+
+	await expect(contact_link).toBeVisible()
+	await expect(contact_link).toHaveAttribute('href', CONTACT_URL_PATTERN)
+	expect(await page.content()).not.toContain(PLAINTEXT_EMAIL)
+}
 
 test.describe('Privacy Policy page', () => {
 	test(RENDERS_H1_AND_LAST_UPDATED, async ({ page }) => {
@@ -63,7 +84,7 @@ test.describe('Terms of Service page', () => {
 			'Disclaimers',
 			'Limitation of Liability',
 			'Governing Law and Jurisdiction',
-			'Contact Us',
+			CONTACT_US_HEADING,
 		]
 
 		for (const title of section_titles) {
@@ -83,6 +104,16 @@ test.describe('Terms of Service page', () => {
 
 		await expect(privacy_link).toBeVisible()
 		await expect(privacy_link).toHaveAttribute('href', PRIVACY_URL_PATTERN)
+	})
+})
+
+test.describe('Contact Us cross-links on legal pages', () => {
+	test(`Privacy: ${CONTACT_SECTION_TEST_NAME}`, async ({ page }) => {
+		await assert_contact_us_cross_link(page, PRIVACY_PATH)
+	})
+
+	test(`Terms: ${CONTACT_SECTION_TEST_NAME}`, async ({ page }) => {
+		await assert_contact_us_cross_link(page, TERMS_PATH)
 	})
 })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.151.0",
+	"version": "0.152.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {

--- a/src/lib/components/PageFooterLine.svelte
+++ b/src/lib/components/PageFooterLine.svelte
@@ -3,6 +3,12 @@
 	import { APP, AUTHOR } from '$lib/app'
 	import { CONTENT_EDGE_SPACING_CLASS, LINK_BASE_CLASS } from '$lib/constants/layout'
 	import { PAGES } from '$lib/types/page'
+
+	const FOOTER_LINKS = [
+		{ href: resolve('/contact'), title: PAGES.CONTACT.title },
+		{ href: resolve('/privacy'), title: PAGES.PRIVACY_POLICY.title },
+		{ href: resolve('/terms'), title: PAGES.TERMS_OF_SERVICE.title },
+	]
 </script>
 
 <div
@@ -10,19 +16,12 @@
 >
 	<div class="flex flex-col items-center gap-1 text-sm text-white/60">
 		<div class="flex flex-wrap items-center justify-center gap-x-2 gap-y-1">
-			{#if PAGES.PRIVACY_POLICY.link}
-				<a href={resolve(PAGES.PRIVACY_POLICY.link as '/privacy')} class={LINK_BASE_CLASS}>
-					{PAGES.PRIVACY_POLICY.title}
-				</a>
-			{/if}
-			{#if PAGES.PRIVACY_POLICY.link && PAGES.TERMS_OF_SERVICE.link}
-				<span aria-hidden="true">·</span>
-			{/if}
-			{#if PAGES.TERMS_OF_SERVICE.link}
-				<a href={resolve(PAGES.TERMS_OF_SERVICE.link as '/terms')} class={LINK_BASE_CLASS}>
-					{PAGES.TERMS_OF_SERVICE.title}
-				</a>
-			{/if}
+			{#each FOOTER_LINKS as footer_link, index (footer_link.href)}
+				{#if index > 0}
+					<span aria-hidden="true">·</span>
+				{/if}
+				<a href={footer_link.href} class={LINK_BASE_CLASS}>{footer_link.title}</a>
+			{/each}
 		</div>
 		<span>{AUTHOR.COPYRIGHT}</span>
 		<a href={resolve('/')} class="{LINK_BASE_CLASS} hidden" aria-hidden="true">

--- a/src/lib/data/social-links.ts
+++ b/src/lib/data/social-links.ts
@@ -18,5 +18,17 @@ const HEADER_SOCIAL_LINKS: Array<SocialLink> = [
 	{ href: URLS.YOUTUBE, aria_label: 'YouTube', icon: YouTubeIcon, is_external: true },
 ]
 
+const CONTACT_SOCIAL_LINKS: Array<SocialLink> = [
+	{ href: URLS.X, aria_label: 'X', icon: XIcon, is_external: true, label: 'X (Twitter)' },
+	{ href: URLS.GITHUB, aria_label: 'GitHub', icon: GitHubIcon, is_external: true, label: 'GitHub' },
+	{
+		href: URLS.YOUTUBE,
+		aria_label: 'YouTube',
+		icon: YouTubeIcon,
+		is_external: true,
+		label: 'YouTube',
+	},
+]
+
 export type { SocialLink }
-export { HEADER_SOCIAL_LINKS }
+export { CONTACT_SOCIAL_LINKS, HEADER_SOCIAL_LINKS }

--- a/src/lib/icons/EyeIcon.svelte
+++ b/src/lib/icons/EyeIcon.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import BaseIcon from '$lib/icons/BaseIcon.svelte'
+
+	const {
+		size = '1.5rem',
+		title = 'Reveal',
+		aria_label,
+		class: class_name = '',
+	} = $props<{
+		size?: string
+		title?: string
+		aria_label?: string
+		class?: string
+	}>()
+</script>
+
+<BaseIcon {size} {title} {aria_label} class={class_name}>
+	<path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z"></path>
+	<circle cx="12" cy="12" r="3"></circle>
+</BaseIcon>

--- a/src/lib/types/page.ts
+++ b/src/lib/types/page.ts
@@ -1,6 +1,7 @@
 import { APP, AUTHOR, OPENCOLLECTIVE, URLS } from '$lib/app'
 import BlogIcon from '$lib/icons/BlogIcon.svelte'
 import LinkIcon from '$lib/icons/LinkIcon.svelte'
+import MailIcon from '$lib/icons/MailIcon.svelte'
 import OpenCollectiveIcon from '$lib/icons/OpenCollectiveIcon.svelte'
 import PrivacyPolicyIcon from '$lib/icons/PrivacyPolicyIcon.svelte'
 import ProjectsIcon from '$lib/icons/ProjectsIcon.svelte'
@@ -22,6 +23,7 @@ type PageKey =
 	| 'PROJECTS'
 	| 'PROFILE'
 	| 'SOCIAL_LINKS'
+	| 'CONTACT'
 	| 'PRIVACY_POLICY'
 	| 'TERMS_OF_SERVICE'
 	| 'DONATIONS'
@@ -60,6 +62,13 @@ const SOCIAL_LINKS: Page = {
 	description: 'Connect with me',
 }
 
+const CONTACT: Page = {
+	icon: MailIcon,
+	title: 'Contact',
+	description: 'Get in touch',
+	link: '/contact',
+}
+
 const PRIVACY_POLICY: Page = {
 	icon: PrivacyPolicyIcon,
 	title: 'Privacy Policy',
@@ -94,6 +103,7 @@ const PAGES: Record<PageKey, Page> = {
 	PROJECTS,
 	PROFILE,
 	SOCIAL_LINKS,
+	CONTACT,
 	PRIVACY_POLICY,
 	TERMS_OF_SERVICE,
 	DONATIONS,

--- a/src/lib/utils/email-utilities.spec.ts
+++ b/src/lib/utils/email-utilities.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { email_utilities } from './email-utilities'
+
+const SAMPLE_LOCAL = 'user'
+const SAMPLE_DOMAIN = 'example.com'
+const SAMPLE_EMAIL = 'user@example.com'
+
+describe('email_utilities.assemble', () => {
+	it('joins local and domain parts with an @ sign', () => {
+		expect(email_utilities.assemble(SAMPLE_LOCAL, SAMPLE_DOMAIN)).toBe(SAMPLE_EMAIL)
+	})
+
+	it('does not require the inputs to contain an @ sign', () => {
+		const local = 'alice'
+		const domain = 'corp.example.com'
+
+		expect(local).not.toContain('@')
+		expect(domain).not.toContain('@')
+		expect(email_utilities.assemble(local, domain)).toBe('alice@corp.example.com')
+	})
+})
+
+describe('email_utilities.split', () => {
+	it('splits a normal email into local and domain parts', () => {
+		expect(email_utilities.split(SAMPLE_EMAIL)).toEqual({
+			local: SAMPLE_LOCAL,
+			domain: SAMPLE_DOMAIN,
+		})
+	})
+
+	it('returns empty domain for a string without an @ sign', () => {
+		expect(email_utilities.split('noop')).toEqual({ local: 'noop', domain: '' })
+	})
+
+	it('round-trips through assemble', () => {
+		const original = 'joshuafolkken@gmail.com'
+		const { local, domain } = email_utilities.split(original)
+
+		expect(email_utilities.assemble(local, domain)).toBe(original)
+	})
+})

--- a/src/lib/utils/email-utilities.ts
+++ b/src/lib/utils/email-utilities.ts
@@ -1,0 +1,16 @@
+function assemble(local: string, domain: string): string {
+	return `${local}@${domain}`
+}
+
+function split(email: string): { local: string; domain: string } {
+	const [local = '', domain = ''] = email.split('@')
+
+	return { local, domain }
+}
+
+const email_utilities = {
+	assemble,
+	split,
+}
+
+export { email_utilities }

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import { AUTHOR } from '$lib/app'
+	import PageHeader from '$lib/components/PageHeader.svelte'
+	import PageLayout from '$lib/components/PageLayout.svelte'
+	import PageSection from '$lib/components/PageSection.svelte'
+	import SocialLinkItem from '$lib/components/SocialLinkItem.svelte'
+	import { ICON_SIZE_MD } from '$lib/constants/layout'
+	import { CONTACT_SOCIAL_LINKS } from '$lib/data/social-links'
+	import { PAGES } from '$lib/types/page'
+	import EmailReveal from './EmailReveal.svelte'
+
+	const SOCIAL_LINK_CLASS =
+		'inline-flex items-center gap-3 rounded-lg border border-white/10 bg-slate-800/30 px-4 py-2 text-white/80 transition hover:border-white/30 hover:bg-slate-800/70 hover:text-white'
+</script>
+
+<svelte:head>
+	<title>{PAGES.CONTACT.title} - {AUTHOR.NAME}</title>
+	<meta name="description" content={PAGES.CONTACT.description} />
+</svelte:head>
+
+<PageLayout>
+	<PageHeader page={PAGES.CONTACT} />
+
+	<PageSection title="Connect on social">
+		<p class="mb-4">
+			The quickest way to reach out is through social channels — DM, comment, or subscribe.
+		</p>
+		<ul class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+			{#each CONTACT_SOCIAL_LINKS as link (link.href)}
+				<li>
+					<SocialLinkItem {link} has_label icon_size={ICON_SIZE_MD} class={SOCIAL_LINK_CLASS} />
+				</li>
+			{/each}
+		</ul>
+	</PageSection>
+
+	<PageSection title="Email">
+		<p class="mb-4">
+			Prefer email? Click below to reveal the address — we keep it hidden from the page source to
+			reduce spam.
+		</p>
+		<EmailReveal />
+	</PageSection>
+</PageLayout>

--- a/src/routes/contact/EmailReveal.svelte
+++ b/src/routes/contact/EmailReveal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { AUTHOR } from '$lib/app'
 	import { ICON_SIZE_MD, LINK_BASE_DEFAULT_CLASS } from '$lib/constants/layout'
+	import EyeIcon from '$lib/icons/EyeIcon.svelte'
 	import MailIcon from '$lib/icons/MailIcon.svelte'
 	import { email_utilities } from '$lib/utils/email-utilities'
 
@@ -9,7 +10,9 @@
 	const MAILTO_HREF = `mailto:${EMAIL_VALUE}`
 
 	const BUTTON_CLASS =
-		'inline-flex items-center gap-2 rounded-lg border border-white/15 bg-slate-800/40 px-4 py-2 text-white/80 transition hover:border-white/30 hover:bg-slate-800/70 hover:text-white'
+		'group inline-flex items-center gap-2 rounded-lg border border-white/15 bg-slate-800/40 px-4 py-2 text-white/80 transition hover:border-white/30 hover:bg-slate-800/70 hover:text-white'
+	const ICON_DEFAULT_CLASS = 'pointer-events-none inline-flex group-hover:hidden'
+	const ICON_HOVER_CLASS = 'pointer-events-none hidden group-hover:inline-flex'
 
 	let is_revealed = $state(false)
 
@@ -25,7 +28,12 @@
 	</a>
 {:else}
 	<button type="button" class={BUTTON_CLASS} onclick={reveal} data-testid="contact-email-reveal">
-		<MailIcon size={ICON_SIZE_MD} />
+		<span class={ICON_DEFAULT_CLASS} data-testid="contact-email-reveal-icon-default">
+			<MailIcon size={ICON_SIZE_MD} />
+		</span>
+		<span class={ICON_HOVER_CLASS} data-testid="contact-email-reveal-icon-hover">
+			<EyeIcon size={ICON_SIZE_MD} />
+		</span>
 		<span>Reveal email address</span>
 	</button>
 {/if}

--- a/src/routes/contact/EmailReveal.svelte
+++ b/src/routes/contact/EmailReveal.svelte
@@ -10,7 +10,7 @@
 	const MAILTO_HREF = `mailto:${EMAIL_VALUE}`
 
 	const BUTTON_CLASS =
-		'group inline-flex items-center gap-2 rounded-lg border border-white/15 bg-slate-800/40 px-4 py-2 text-white/80 transition hover:border-white/30 hover:bg-slate-800/70 hover:text-white'
+		'group inline-flex cursor-pointer items-center gap-2 rounded-lg border border-white/15 bg-slate-800/40 px-4 py-2 text-white/80 transition hover:border-white/30 hover:bg-slate-800/70 hover:text-white'
 	const ICON_DEFAULT_CLASS = 'pointer-events-none inline-flex group-hover:hidden'
 	const ICON_HOVER_CLASS = 'pointer-events-none hidden group-hover:inline-flex'
 

--- a/src/routes/contact/EmailReveal.svelte
+++ b/src/routes/contact/EmailReveal.svelte
@@ -5,48 +5,26 @@
 	import { email_utilities } from '$lib/utils/email-utilities'
 
 	const { local: EMAIL_LOCAL, domain: EMAIL_DOMAIN } = email_utilities.split(AUTHOR.EMAIL)
-
-	let is_revealed = $state(false)
-	let is_copied = $state(false)
-
-	const email = $derived(email_utilities.assemble(EMAIL_LOCAL, EMAIL_DOMAIN))
-
-	async function reveal_and_copy(): Promise<void> {
-		is_revealed = true
-
-		try {
-			await navigator.clipboard.writeText(email)
-			is_copied = true
-		} catch {
-			is_copied = false
-		}
-	}
-
-	function handle_click(): void {
-		void reveal_and_copy()
-	}
+	const EMAIL_VALUE = email_utilities.assemble(EMAIL_LOCAL, EMAIL_DOMAIN)
+	const MAILTO_HREF = `mailto:${EMAIL_VALUE}`
 
 	const BUTTON_CLASS =
 		'inline-flex items-center gap-2 rounded-lg border border-white/15 bg-slate-800/40 px-4 py-2 text-white/80 transition hover:border-white/30 hover:bg-slate-800/70 hover:text-white'
+
+	let is_revealed = $state(false)
+
+	function reveal(): void {
+		is_revealed = true
+	}
 </script>
 
 {#if is_revealed}
-	<div class="flex flex-col gap-1">
-		<a href="mailto:{email}" class="{LINK_BASE_DEFAULT_CLASS} inline-flex items-center gap-2">
-			<MailIcon size={ICON_SIZE_MD} />
-			<span data-testid="contact-email-address">{email}</span>
-		</a>
-		{#if is_copied}
-			<span class="text-sm text-white/60" aria-live="polite">Copied to clipboard</span>
-		{/if}
-	</div>
+	<a href={MAILTO_HREF} class="{LINK_BASE_DEFAULT_CLASS} inline-flex items-center gap-2">
+		<MailIcon size={ICON_SIZE_MD} />
+		<span data-testid="contact-email-address">{EMAIL_VALUE}</span>
+	</a>
 {:else}
-	<button
-		type="button"
-		class={BUTTON_CLASS}
-		onclick={handle_click}
-		data-testid="contact-email-reveal"
-	>
+	<button type="button" class={BUTTON_CLASS} onclick={reveal} data-testid="contact-email-reveal">
 		<MailIcon size={ICON_SIZE_MD} />
 		<span>Reveal email address</span>
 	</button>

--- a/src/routes/contact/EmailReveal.svelte
+++ b/src/routes/contact/EmailReveal.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import { AUTHOR } from '$lib/app'
+	import { ICON_SIZE_MD, LINK_BASE_DEFAULT_CLASS } from '$lib/constants/layout'
+	import MailIcon from '$lib/icons/MailIcon.svelte'
+	import { email_utilities } from '$lib/utils/email-utilities'
+
+	const { local: EMAIL_LOCAL, domain: EMAIL_DOMAIN } = email_utilities.split(AUTHOR.EMAIL)
+
+	let is_revealed = $state(false)
+	let is_copied = $state(false)
+
+	const email = $derived(email_utilities.assemble(EMAIL_LOCAL, EMAIL_DOMAIN))
+
+	async function reveal_and_copy(): Promise<void> {
+		is_revealed = true
+
+		try {
+			await navigator.clipboard.writeText(email)
+			is_copied = true
+		} catch {
+			is_copied = false
+		}
+	}
+
+	function handle_click(): void {
+		void reveal_and_copy()
+	}
+
+	const BUTTON_CLASS =
+		'inline-flex items-center gap-2 rounded-lg border border-white/15 bg-slate-800/40 px-4 py-2 text-white/80 transition hover:border-white/30 hover:bg-slate-800/70 hover:text-white'
+</script>
+
+{#if is_revealed}
+	<div class="flex flex-col gap-1">
+		<a href="mailto:{email}" class="{LINK_BASE_DEFAULT_CLASS} inline-flex items-center gap-2">
+			<MailIcon size={ICON_SIZE_MD} />
+			<span data-testid="contact-email-address">{email}</span>
+		</a>
+		{#if is_copied}
+			<span class="text-sm text-white/60" aria-live="polite">Copied to clipboard</span>
+		{/if}
+	</div>
+{:else}
+	<button
+		type="button"
+		class={BUTTON_CLASS}
+		onclick={handle_click}
+		data-testid="contact-email-reveal"
+	>
+		<MailIcon size={ICON_SIZE_MD} />
+		<span>Reveal email address</span>
+	</button>
+{/if}

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -11,6 +11,7 @@
 
 	const last_updated = LAST_UPDATED.PRIVACY_POLICY
 	const terms_href = resolve('/terms')
+	const contact_href = resolve('/contact')
 </script>
 
 <svelte:head>
@@ -185,8 +186,8 @@
 			</li>
 		</ul>
 		<p class="mt-2">
-			To exercise these rights, please contact us using the information provided in the "Contact Us"
-			section below.
+			To exercise these rights, please reach out via our
+			<a href={contact_href} class={LINK_BASE_CLASS}>Contact page</a>.
 		</p>
 	</PageSection>
 
@@ -246,19 +247,10 @@
 	</PageSection>
 
 	<PageSection title="Contact Us">
-		<p class="mb-2">
+		<p>
 			If you have any questions, concerns, or requests regarding this Privacy Policy or our data
-			practices, please contact us at:
+			practices, please reach out via our
+			<a href={contact_href} class={LINK_BASE_CLASS}>Contact page</a>.
 		</p>
-		<div class="space-y-1">
-			<p>
-				<strong>Email:</strong>
-				{AUTHOR.EMAIL}
-			</p>
-			<p>
-				<strong>Website:</strong>
-				{APP.URL}
-			</p>
-		</div>
 	</PageSection>
 </PageLayout>

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -10,6 +10,7 @@
 
 	const last_updated = LAST_UPDATED.TERMS_OF_SERVICE
 	const privacy_href = resolve('/privacy')
+	const contact_href = resolve('/contact')
 </script>
 
 <svelte:head>
@@ -84,8 +85,8 @@
 		<p>
 			By submitting content, you grant us a worldwide, non-exclusive, royalty-free license to use,
 			reproduce, adapt, and display that content in connection with operating and improving the
-			Site. You can revoke this license by asking us to remove your content; see the "Contact Us"
-			section.
+			Site. You can revoke this license by asking us to remove your content via our
+			<a href={contact_href} class={LINK_BASE_CLASS}>Contact page</a>.
 		</p>
 	</PageSection>
 
@@ -159,16 +160,9 @@
 	</PageSection>
 
 	<PageSection title="Contact Us">
-		<p class="mb-2">If you have questions about these Terms, please contact us at:</p>
-		<div class="space-y-1">
-			<p>
-				<strong>Email:</strong>
-				{AUTHOR.EMAIL}
-			</p>
-			<p>
-				<strong>Website:</strong>
-				{APP.URL}
-			</p>
-		</div>
+		<p>
+			If you have questions about these Terms, please reach out via our
+			<a href={contact_href} class={LINK_BASE_CLASS}>Contact page</a>.
+		</p>
 	</PageSection>
 </PageLayout>


### PR DESCRIPTION
## Summary

- Add `/contact` page for AdSense compliance: social channels first (X → GitHub → YouTube), then spam-protected email reveal
- Consolidate all contact touchpoints on `/contact` — Privacy and Terms legal pages now link to `/contact` instead of rendering the email as plaintext

## Changes

- New `/contact` route with `EmailReveal.svelte` (email kept out of initial HTML, revealed on click)
- New `src/lib/utils/email-utilities.ts` (`assemble` / `split`) with unit tests
- Register `CONTACT` page in `PAGES` registry and add `CONTACT_SOCIAL_LINKS`
- Refactor `PageFooterLine.svelte` to iterate over a `FOOTER_LINKS` list; add Contact entry
- Rewrite the Contact Us sections in `src/routes/privacy/+page.svelte` and `src/routes/terms/+page.svelte` to link to `/contact`; remove plaintext email and update in-page cross-references
- New `e2e/contact.test.ts` (h1, social link order / hrefs, no plaintext email in initial HTML, reveal flow, footer link)
- Extend `e2e/legal-pages.test.ts` with a shared `assert_contact_us_cross_link` helper for Privacy + Terms

## Test plan

- [x] `pnpm run lint`
- [x] `pnpm run check`
- [x] `pnpm cspell:dot`
- [x] `pnpm test:unit --run` (117 passed)
- [x] `pnpm test:e2e` (16 passed, via pre-push hook)

Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)