### PR TITLE
feat: unify section heading style with tech stack icon treatment #441

### DIFF
--- a/e2e/section-headings.test.ts
+++ b/e2e/section-headings.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 const HOME_PATH = '/'
+const PROFILE_PATH = '/profile'
 
 const HEADING_ROLE = 'heading'
 const LEVEL_2 = 2
@@ -11,16 +12,25 @@ const SKILLS = 'Skills'
 const DISCOVER = 'Discover'
 const TOP_SUPPORTERS = 'Top Supporters'
 
-const UNIFIED_HEADINGS = [TECH_STACK, FEATURED_PROJECTS, SKILLS, DISCOVER, TOP_SUPPORTERS]
+const UNIFIED_HEADINGS: ReadonlyArray<{ name: string; path: string }> = [
+	{ name: TECH_STACK, path: PROFILE_PATH },
+	{ name: FEATURED_PROJECTS, path: HOME_PATH },
+	{ name: SKILLS, path: HOME_PATH },
+	{ name: DISCOVER, path: HOME_PATH },
+	{ name: TOP_SUPPORTERS, path: HOME_PATH },
+]
 
-const FORMERLY_CENTERED_HEADINGS = [DISCOVER, TOP_SUPPORTERS]
+const FORMERLY_CENTERED_HEADINGS: ReadonlyArray<{ name: string; path: string }> = [
+	{ name: DISCOVER, path: HOME_PATH },
+	{ name: TOP_SUPPORTERS, path: HOME_PATH },
+]
 
 test.describe('Unified section headings', () => {
-	for (const heading_name of UNIFIED_HEADINGS) {
-		test(`${heading_name} heading renders with a sibling icon`, async ({ page }) => {
-			await page.goto(HOME_PATH)
+	for (const { name, path } of UNIFIED_HEADINGS) {
+		test(`${name} heading renders with a sibling icon`, async ({ page }) => {
+			await page.goto(path)
 
-			const heading = page.getByRole(HEADING_ROLE, { level: LEVEL_2, name: heading_name })
+			const heading = page.getByRole(HEADING_ROLE, { level: LEVEL_2, name })
 
 			await expect(heading).toBeVisible()
 
@@ -30,11 +40,11 @@ test.describe('Unified section headings', () => {
 		})
 	}
 
-	for (const heading_name of FORMERLY_CENTERED_HEADINGS) {
-		test(`${heading_name} heading is no longer centered`, async ({ page }) => {
-			await page.goto(HOME_PATH)
+	for (const { name, path } of FORMERLY_CENTERED_HEADINGS) {
+		test(`${name} heading is no longer centered`, async ({ page }) => {
+			await page.goto(path)
 
-			const heading = page.getByRole(HEADING_ROLE, { level: LEVEL_2, name: heading_name })
+			const heading = page.getByRole(HEADING_ROLE, { level: LEVEL_2, name })
 
 			await expect(heading).not.toHaveCSS('text-align', 'center')
 

--- a/e2e/section-headings.test.ts
+++ b/e2e/section-headings.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test'
+
+const HOME_PATH = '/'
+
+const HEADING_ROLE = 'heading'
+const LEVEL_2 = 2
+
+const TECH_STACK = 'Tech Stack'
+const FEATURED_PROJECTS = 'Featured Projects'
+const SKILLS = 'Skills'
+const DISCOVER = 'Discover'
+const TOP_SUPPORTERS = 'Top Supporters'
+
+const UNIFIED_HEADINGS = [TECH_STACK, FEATURED_PROJECTS, SKILLS, DISCOVER, TOP_SUPPORTERS]
+
+const FORMERLY_CENTERED_HEADINGS = [DISCOVER, TOP_SUPPORTERS]
+
+test.describe('Unified section headings', () => {
+	for (const heading_name of UNIFIED_HEADINGS) {
+		test(`${heading_name} heading renders with a sibling icon`, async ({ page }) => {
+			await page.goto(HOME_PATH)
+
+			const heading = page.getByRole(HEADING_ROLE, { level: LEVEL_2, name: heading_name })
+
+			await expect(heading).toBeVisible()
+
+			const heading_row = heading.locator('..')
+
+			await expect(heading_row.locator('svg').first()).toBeVisible()
+		})
+	}
+
+	for (const heading_name of FORMERLY_CENTERED_HEADINGS) {
+		test(`${heading_name} heading is no longer centered`, async ({ page }) => {
+			await page.goto(HOME_PATH)
+
+			const heading = page.getByRole(HEADING_ROLE, { level: LEVEL_2, name: heading_name })
+
+			await expect(heading).not.toHaveCSS('text-align', 'center')
+
+			const heading_row = heading.locator('..')
+
+			await expect(heading_row).not.toHaveCSS('justify-content', 'center')
+		})
+	}
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.152.0",
+	"version": "0.153.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {

--- a/src/lib/components/PageFooter.svelte
+++ b/src/lib/components/PageFooter.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
 	import RevealSection from '$lib/components/RevealSection.svelte'
-	import { SECTION_HEADING_PRIMARY_CLASS } from '$lib/constants/typography'
+	import SectionHeading from '$lib/components/SectionHeading.svelte'
+	import HeartIcon from '$lib/icons/HeartIcon.svelte'
 	import SupportersList from './SupportersList.svelte'
 </script>
 
 <footer class="space-y-6 text-sm text-white/60">
 	<RevealSection py="py-12">
-		<h2 class="mb-12 text-center {SECTION_HEADING_PRIMARY_CLASS}">Top Supporters</h2>
+		<SectionHeading icon={HeartIcon} title="Top Supporters" class="mb-12" />
 		<SupportersList />
 	</RevealSection>
 </footer>

--- a/src/lib/components/SectionHeading.svelte
+++ b/src/lib/components/SectionHeading.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import {
+		SECTION_HEADING_LIGHT_LG_CLASS,
+		SECTION_ICON_SIZE,
+		SECTION_ICON_WRAPPER_CLASS,
+	} from '$lib/constants/typography'
+	import type { Component } from 'svelte'
+
+	interface Props {
+		icon: Component
+		title: string
+		subtitle?: string | undefined
+		class?: string | undefined
+	}
+
+	const { icon, title, subtitle, class: class_name = '' }: Props = $props()
+</script>
+
+<div class={class_name}>
+	<div class="flex items-center gap-3">
+		<div class={SECTION_ICON_WRAPPER_CLASS}>
+			{#if icon}
+				<!-- eslint-disable-next-line @typescript-eslint/naming-convention -->
+				{@const Icon = icon}
+				<Icon size={SECTION_ICON_SIZE} />
+			{/if}
+		</div>
+		<h2 class={SECTION_HEADING_LIGHT_LG_CLASS}>{title}</h2>
+	</div>
+	{#if subtitle}
+		<p class="mt-2 text-white/50">{subtitle}</p>
+	{/if}
+</div>

--- a/src/lib/components/SkillsSection.svelte
+++ b/src/lib/components/SkillsSection.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
 	import RevealOnIntersect from '$lib/components/RevealOnIntersect.svelte'
+	import SectionHeading from '$lib/components/SectionHeading.svelte'
 	import TechPill from '$lib/components/TechPill.svelte'
 	import { TECH_PILL_LIFT_CLASS } from '$lib/constants/hover-styles'
-	import { SECTION_HEADING_PRIMARY_CLASS } from '$lib/constants/typography'
 	import { SKILLS } from '$lib/data/skills'
 	import { tech_colors } from '$lib/data/tech-colors'
+	import SparklesIcon from '$lib/icons/SparklesIcon.svelte'
 	import { SvelteSet } from 'svelte/reactivity'
 
 	const revealed = new SvelteSet<string>()
@@ -14,8 +15,12 @@
 </script>
 
 <section>
-	<h2 class="mb-2 {SECTION_HEADING_PRIMARY_CLASS}">Skills</h2>
-	<p class="mb-10 text-white/50">Technical and beyond.</p>
+	<SectionHeading
+		icon={SparklesIcon}
+		title="Skills"
+		subtitle="Technical and beyond."
+		class="mb-10"
+	/>
 
 	<div class="grid gap-x-8 gap-y-6 sm:grid-cols-2">
 		{#each SKILLS as skill (skill.name)}

--- a/src/lib/components/TechStack.svelte
+++ b/src/lib/components/TechStack.svelte
@@ -1,25 +1,17 @@
 <script lang="ts">
 	import RevealOnIntersect from '$lib/components/RevealOnIntersect.svelte'
+	import SectionHeading from '$lib/components/SectionHeading.svelte'
 	import TechPill from '$lib/components/TechPill.svelte'
 	import { CARD_BASE_CLASS } from '$lib/constants/card-styles'
 	import { TECH_PILL_LIFT_CLASS } from '$lib/constants/hover-styles'
-	import { SECTION_HEADING_LIGHT_LG_CLASS } from '$lib/constants/typography'
 	import { TECH_STACK } from '$lib/data/tech-stack'
 	import ToolIcon from '$lib/icons/ToolIcon.svelte'
 
 	const SECTION_MIN_HEIGHT_PX = 50
-	const SECTION_ICON_SIZE = '1.25rem'
-	const SECTION_ICON_WRAPPER_CLASS =
-		'flex items-center justify-center rounded-xl border border-sky-400/30 bg-sky-500/10 p-2 text-sky-400 shadow-[0_0_15px_rgba(56,189,248,0.2)] ring-1 ring-sky-400/20 ring-inset'
 </script>
 
 <section class="my-16">
-	<div class="mb-10 flex items-center gap-3">
-		<div class={SECTION_ICON_WRAPPER_CLASS}>
-			<ToolIcon size={SECTION_ICON_SIZE} />
-		</div>
-		<h2 class={SECTION_HEADING_LIGHT_LG_CLASS}>Tech Stack</h2>
-	</div>
+	<SectionHeading icon={ToolIcon} title="Tech Stack" class="mb-10" />
 
 	<div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
 		{#each TECH_STACK as category (category.title)}

--- a/src/lib/constants/typography.ts
+++ b/src/lib/constants/typography.ts
@@ -1,12 +1,15 @@
-/** Shared h2 style for major section titles (home, footer blocks, skills). */
-const SECTION_HEADING_PRIMARY_CLASS = 'text-3xl font-bold tracking-tight text-white'
-
 const SECTION_HEADING_LIGHT_LG_CLASS = 'text-3xl font-light tracking-tight text-white/90'
 
 const SECTION_HEADING_LIGHT_SM_CLASS = 'text-2xl font-light tracking-tight text-white/90'
 
+const SECTION_ICON_SIZE = '1.25rem'
+
+const SECTION_ICON_WRAPPER_CLASS =
+	'flex items-center justify-center rounded-xl border border-sky-400/30 bg-sky-500/10 p-2 text-sky-400 shadow-[0_0_15px_rgba(56,189,248,0.2)] ring-1 ring-sky-400/20 ring-inset'
+
 export {
 	SECTION_HEADING_LIGHT_LG_CLASS,
 	SECTION_HEADING_LIGHT_SM_CLASS,
-	SECTION_HEADING_PRIMARY_CLASS,
+	SECTION_ICON_SIZE,
+	SECTION_ICON_WRAPPER_CLASS,
 }

--- a/src/lib/icons/BriefcaseIcon.svelte
+++ b/src/lib/icons/BriefcaseIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import BaseIcon from '$lib/icons/BaseIcon.svelte'
+
+	const {
+		size = '1.5rem',
+		title = 'Briefcase',
+		aria_label,
+	} = $props<{
+		size?: string
+		title?: string
+		aria_label?: string
+	}>()
+</script>
+
+<BaseIcon {size} {title} {aria_label}>
+	<!-- Briefcase -->
+	<rect x="2" y="7" width="20" height="14" rx="2"></rect>
+	<path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path>
+</BaseIcon>

--- a/src/lib/icons/CompassIcon.svelte
+++ b/src/lib/icons/CompassIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import BaseIcon from '$lib/icons/BaseIcon.svelte'
+
+	const {
+		size = '1.5rem',
+		title = 'Compass',
+		aria_label,
+	} = $props<{
+		size?: string
+		title?: string
+		aria_label?: string
+	}>()
+</script>
+
+<BaseIcon {size} {title} {aria_label}>
+	<!-- Compass -->
+	<circle cx="12" cy="12" r="10"></circle>
+	<polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76"></polygon>
+</BaseIcon>

--- a/src/lib/icons/SparklesIcon.svelte
+++ b/src/lib/icons/SparklesIcon.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+	import BaseIcon from '$lib/icons/BaseIcon.svelte'
+
+	const {
+		size = '1.5rem',
+		title = 'Sparkles',
+		aria_label,
+	} = $props<{
+		size?: string
+		title?: string
+		aria_label?: string
+	}>()
+</script>
+
+<BaseIcon {size} {title} {aria_label}>
+	<!-- Sparkles -->
+	<path
+		d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"
+	></path>
+	<path d="M20 3v4"></path>
+	<path d="M22 5h-4"></path>
+	<path d="M4 17v2"></path>
+	<path d="M5 18H3"></path>
+</BaseIcon>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
 	import PageLayout from '$lib/components/PageLayout.svelte'
 	import ProjectCard from '$lib/components/ProjectCard.svelte'
 	import RevealSection from '$lib/components/RevealSection.svelte'
+	import SectionHeading from '$lib/components/SectionHeading.svelte'
 	import SkillsSection from '$lib/components/SkillsSection.svelte'
 	import {
 		CARD_BASE_CLASS,
@@ -10,8 +11,9 @@
 		CARD_TITLE_CLASS,
 	} from '$lib/constants/card-styles'
 	import { ICON_SIZE_2XL, MAIN_CONTENT_ID } from '$lib/constants/layout'
-	import { SECTION_HEADING_PRIMARY_CLASS } from '$lib/constants/typography'
 	import { FEATURED_PROJECTS } from '$lib/data/projects'
+	import BriefcaseIcon from '$lib/icons/BriefcaseIcon.svelte'
+	import CompassIcon from '$lib/icons/CompassIcon.svelte'
 	import { MAIN_NAV_PAGES, PAGES } from '$lib/types/page'
 	import { link_utilities } from '$lib/utils/link-utilities'
 </script>
@@ -25,8 +27,11 @@
 	<RevealSection>
 		<div class="mb-12 flex items-end justify-between">
 			<div>
-				<h2 class={SECTION_HEADING_PRIMARY_CLASS}>Featured Projects</h2>
-				<p class="mt-2 text-white/50">A selection of my recent work and experiments.</p>
+				<SectionHeading
+					icon={BriefcaseIcon}
+					title="Featured Projects"
+					subtitle="A selection of my recent work and experiments."
+				/>
 			</div>
 			<a
 				href={link_utilities.get_href(PAGES.PROJECTS.link)}
@@ -52,7 +57,7 @@
 
 	<!-- Quick Navigation -->
 	<RevealSection>
-		<h2 class="mb-12 text-center {SECTION_HEADING_PRIMARY_CLASS}">Discover</h2>
+		<SectionHeading icon={CompassIcon} title="Discover" class="mb-12" />
 		<div class="grid gap-6 lg:grid-cols-3">
 			{#each MAIN_NAV_PAGES as p (p.title)}
 				<a


### PR DESCRIPTION
## Summary

- Unify all 5 section headings (`Tech Stack`, `Featured Projects`, `Skills`, `Discover`, `Top Supporters`) to the Tech Stack treatment: sky-400 icon chip + `font-light` title.
- Standardize alignment to **left-aligned** (remove `text-center` from `Discover` and `Top Supporters`).
- Introduce reusable `SectionHeading.svelte` component (props: `icon`, `title`, `subtitle?`, `class?`) and apply at all 5 call sites.
- Add 3 new icon components: `BriefcaseIcon`, `SparklesIcon`, `CompassIcon` (each heading gets a distinct icon).
- Remove the now-unused `SECTION_HEADING_PRIMARY_CLASS` constant.

Closes #441

## Test plan

- [ ] `pnpm run lint` passes
- [ ] `pnpm run check` passes
- [ ] `pnpm cspell:dot` passes
- [ ] `pnpm test:unit --run` passes
- [ ] `pnpm exec playwright test e2e/section-headings.test.ts` — 7 new tests pass
- [ ] Visual check `/`: Featured Projects, Skills, Discover all left-aligned with distinct sky-400 icon chips
- [ ] Visual check `/profile`: Tech Stack unchanged; Skills matches home styling
- [ ] Visual check footer on any page: Top Supporters left-aligned with heart icon chip

🤖 Generated with [Claude Code](https://claude.com/claude-code)