### PR TITLE
Reference refactoring step from collaboration-workflow.md

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.153.0",
+	"version": "0.154.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {

--- a/prompts/collaboration-workflow.md
+++ b/prompts/collaboration-workflow.md
@@ -102,7 +102,8 @@ Issue: <issue-url>
    # 脆弱性が見つかった場合: package.json の overrides に対象バージョンを追加して pnpm install 後に再確認
    ```
 6. 実装を開始する
-7. 実装後は `AGENTS.md` の検証ゲートを実行する
+7. 実装完了後、**lint/test より前に** `prompts/refactoring.md` に従ってリファクタリングを適用する（高・中優先度項目が残らなくなるまで収束させる）
+8. 検証ゲート（`AGENTS.md` / `CLAUDE.md` / `GEMINI.md` の Completion gate）を実行する
 
 `pnpm git` の基本実行（`-y` で確認プロンプトをスキップ）。**初回コミット前に必ず `pnpm version:minor` を実行する。** ただし、同一 PR 内の追加修正コミット（CodeRabbit 指摘対応など）では実行しない。
 


### PR DESCRIPTION
## Summary
- Add a bullet in `prompts/collaboration-workflow.md` Step 3 that references `prompts/refactoring.md` and clarifies refactoring runs before lint/tests.
- Keeps a single source of truth (`prompts/refactoring.md`) for the refactoring rule while making the shared workflow self-sufficient for AI tools that do not read `CLAUDE.md`.

Closes #438

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run check`
- [x] `pnpm cspell:dot`
- [x] Pre-push E2E + unit tests (run via lefthook)

Docs-only change — no unit/E2E tests added (infeasibility, approved during planning).