### PR TITLE
Add AdSenseScript to blog list and blog post pages #469

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -24,6 +24,11 @@ ignorePaths:
   - .fast-check/**
 words:
   - aboutads
+  - adsbygoogle
+  - ADSENSE
+  - adsense
+  - googlesyndication
+  - pagead
   - aikidosec
   - anthropics
   - arrowdown

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -25,6 +25,7 @@ ignorePaths:
 words:
   - aboutads
   - adsbygoogle
+  - domcontentloaded
   - ADSENSE
   - adsense
   - googlesyndication

--- a/e2e/adsense.test.ts
+++ b/e2e/adsense.test.ts
@@ -1,0 +1,54 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const ADSENSE_SRC = 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'
+
+const BLOG_PATH = '/blog'
+const BLOG_POST_PATH = '/blog/driven-by-laziness'
+const ABOUT_PATH = '/about'
+const HOME_PATH = '/'
+const PROJECTS_PATH = '/projects'
+const CONTACT_PATH = '/contact'
+
+async function has_adsense_script(page: Page): Promise<boolean> {
+	const scripts = await page.locator('head script').all()
+
+	for (const script of scripts) {
+		const source = await script.getAttribute('src')
+
+		if (source?.includes(ADSENSE_SRC)) return true
+	}
+
+	return false
+}
+
+test.describe('AdSense script placement', () => {
+	test('present on /about', async ({ page }) => {
+		await page.goto(ABOUT_PATH)
+		expect(await has_adsense_script(page)).toBe(true)
+	})
+
+	test('present on /blog list', async ({ page }) => {
+		await page.goto(BLOG_PATH)
+		expect(await has_adsense_script(page)).toBe(true)
+	})
+
+	test('present on /blog/[slug]', async ({ page }) => {
+		await page.goto(BLOG_POST_PATH)
+		expect(await has_adsense_script(page)).toBe(true)
+	})
+
+	test('absent on /', async ({ page }) => {
+		await page.goto(HOME_PATH)
+		expect(await has_adsense_script(page)).toBe(false)
+	})
+
+	test('absent on /projects', async ({ page }) => {
+		await page.goto(PROJECTS_PATH)
+		expect(await has_adsense_script(page)).toBe(false)
+	})
+
+	test('absent on /contact', async ({ page }) => {
+		await page.goto(CONTACT_PATH)
+		expect(await has_adsense_script(page)).toBe(false)
+	})
+})

--- a/e2e/adsense.test.ts
+++ b/e2e/adsense.test.ts
@@ -23,32 +23,32 @@ async function has_adsense_script(page: Page): Promise<boolean> {
 
 test.describe('AdSense script placement', () => {
 	test('present on /about', async ({ page }) => {
-		await page.goto(ABOUT_PATH)
+		await page.goto(ABOUT_PATH, { waitUntil: 'domcontentloaded' })
 		expect(await has_adsense_script(page)).toBe(true)
 	})
 
 	test('present on /blog list', async ({ page }) => {
-		await page.goto(BLOG_PATH)
+		await page.goto(BLOG_PATH, { waitUntil: 'domcontentloaded' })
 		expect(await has_adsense_script(page)).toBe(true)
 	})
 
 	test('present on /blog/[slug]', async ({ page }) => {
-		await page.goto(BLOG_POST_PATH)
+		await page.goto(BLOG_POST_PATH, { waitUntil: 'domcontentloaded' })
 		expect(await has_adsense_script(page)).toBe(true)
 	})
 
 	test('absent on /', async ({ page }) => {
-		await page.goto(HOME_PATH)
+		await page.goto(HOME_PATH, { waitUntil: 'domcontentloaded' })
 		expect(await has_adsense_script(page)).toBe(false)
 	})
 
 	test('absent on /projects', async ({ page }) => {
-		await page.goto(PROJECTS_PATH)
+		await page.goto(PROJECTS_PATH, { waitUntil: 'domcontentloaded' })
 		expect(await has_adsense_script(page)).toBe(false)
 	})
 
 	test('absent on /contact', async ({ page }) => {
-		await page.goto(CONTACT_PATH)
+		await page.goto(CONTACT_PATH, { waitUntil: 'domcontentloaded' })
 		expect(await has_adsense_script(page)).toBe(false)
 	})
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.165.0",
+	"version": "0.166.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { AUTHOR } from '$lib/app'
+	import AdSenseScript from '$lib/components/AdSenseScript.svelte'
 	import BlogList from '$lib/components/BlogList.svelte'
 	import PageHeader from '$lib/components/PageHeader.svelte'
 	import PageLayout from '$lib/components/PageLayout.svelte'
@@ -13,6 +14,8 @@
 	<title>{PAGES.BLOG.title} - {AUTHOR.NAME}</title>
 	<meta name="description" content={PAGES.BLOG.description} />
 </svelte:head>
+
+<AdSenseScript />
 
 <PageLayout max_width="6xl">
 	<PageHeader page={PAGES.BLOG} />

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { external_links } from '$lib/actions/external-links'
 	import { APP, AUTHOR } from '$lib/app'
+	import AdSenseScript from '$lib/components/AdSenseScript.svelte'
 	import DateDisplay from '$lib/components/DateDisplay.svelte'
 	import EngagementButtons from '$lib/components/EngagementButtons.svelte'
 	import PageHeader from '$lib/components/PageHeader.svelte'
@@ -28,6 +29,8 @@
 	<meta name="twitter:image" content={image_url} />
 	<meta name="twitter:site" content="@{AUTHOR.X_USERNAME}" />
 </svelte:head>
+
+<AdSenseScript />
 
 <PageLayout>
 	<PageHeader page={PAGES.BLOG} />

--- a/static/ads.txt
+++ b/static/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-1014823123178423, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary

- Add `AdSenseScript` component to `/blog` (list) page
- Add `AdSenseScript` component to `/blog/[slug]` (article) pages
- `static/ads.txt` was already created separately
- Add `e2e/adsense.test.ts` verifying script presence on `/about`, `/blog`, `/blog/[slug]` and absence on `/`, `/projects`, `/contact`

Closes #469

## Test plan
- [x] E2E: AdSense script present on `/about`, `/blog`, `/blog/[slug]`
- [x] E2E: AdSense script absent on `/`, `/projects`, `/contact`
- [x] Unit tests: 197 passed
- [x] lint + check:ci + cspell all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)