### PR TITLE
Fix flaky adsense E2E tests: domcontentloaded races Svelte 5 head hydration in CI #495

### DIFF
--- a/e2e/adsense.test.ts
+++ b/e2e/adsense.test.ts
@@ -2,33 +2,24 @@ import { expect, test, type Page } from '@playwright/test'
 import { TEST_ROUTES } from './test-routes'
 
 const ADSENSE_SRC = 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js'
+const ADSENSE_POLL_TIMEOUT = 15_000
+const BLOG_NAV_TIMEOUT = 25_000
+const BLOG_TEST_TIMEOUT = 45_000
 
 async function has_adsense_script(page: Page): Promise<boolean> {
 	const scripts = await page.locator('head script').all()
 
-	for (const script of scripts) {
-		const source = await script.getAttribute('src')
+	const sources = await Promise.all(scripts.map(async (script) => await script.getAttribute('src')))
 
-		if (source?.includes(ADSENSE_SRC)) return true
-	}
-
-	return false
+	return sources.some((source) => source?.includes(ADSENSE_SRC) ?? false)
 }
 
 test.describe('AdSense script placement', () => {
 	test('present on /about', async ({ page }) => {
 		await page.goto(TEST_ROUTES.ABOUT, { waitUntil: 'domcontentloaded' })
-		expect(await has_adsense_script(page)).toBe(true)
-	})
-
-	test('present on /blog list', async ({ page }) => {
-		await page.goto(TEST_ROUTES.BLOG, { waitUntil: 'domcontentloaded' })
-		expect(await has_adsense_script(page)).toBe(true)
-	})
-
-	test('present on /blog/[slug]', async ({ page }) => {
-		await page.goto(TEST_ROUTES.BLOG_POST, { waitUntil: 'domcontentloaded' })
-		expect(await has_adsense_script(page)).toBe(true)
+		await expect
+			.poll(async () => await has_adsense_script(page), { timeout: ADSENSE_POLL_TIMEOUT })
+			.toBe(true)
 	})
 
 	test('absent on /', async ({ page }) => {
@@ -44,5 +35,26 @@ test.describe('AdSense script placement', () => {
 	test('absent on /contact', async ({ page }) => {
 		await page.goto(TEST_ROUTES.CONTACT, { waitUntil: 'domcontentloaded' })
 		expect(await has_adsense_script(page)).toBe(false)
+	})
+})
+
+test.describe('AdSense script placement on blog pages', () => {
+	test.describe.configure({ timeout: BLOG_TEST_TIMEOUT })
+
+	test('present on /blog list', async ({ page }) => {
+		await page.goto(TEST_ROUTES.BLOG, { waitUntil: 'domcontentloaded', timeout: BLOG_NAV_TIMEOUT })
+		await expect
+			.poll(async () => await has_adsense_script(page), { timeout: ADSENSE_POLL_TIMEOUT })
+			.toBe(true)
+	})
+
+	test('present on /blog/[slug]', async ({ page }) => {
+		await page.goto(TEST_ROUTES.BLOG_POST, {
+			waitUntil: 'domcontentloaded',
+			timeout: BLOG_NAV_TIMEOUT,
+		})
+		await expect
+			.poll(async () => await has_adsense_script(page), { timeout: ADSENSE_POLL_TIMEOUT })
+			.toBe(true)
 	})
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.177.0",
+	"version": "0.178.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {


### PR DESCRIPTION
closes #495

## Summary
- Replace `domcontentloaded` + direct check with `expect.poll` for "present" tests, eliminating the Svelte 5 head hydration race (elements temporarily removed then re-inserted during hydration)
- Refactor `has_adsense_script` to use `Promise.all` + `Array.some` (removes nesting >1)
- Split blog-page tests into a separate `test.describe` with extended navigation and test timeouts (`BLOG_NAV_TIMEOUT = 25s`, `BLOG_TEST_TIMEOUT = 45s`) to handle slower dev-server response under concurrent test load

## Test plan
- [ ] All 55 E2E tests pass locally (verified before push)
- [ ] CI E2E runs green — the hydration-race flakiness is eliminated by `expect.poll` retrying until the script stabilizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)