### PR TITLE
Utilities and icon extraction: LinkTypeIcon component and icon size deduplication #512

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.185.0",
+	"version": "0.186.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {

--- a/src/lib/components/LinkTypeIcon.svelte
+++ b/src/lib/components/LinkTypeIcon.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import BlogIcon from '$lib/icons/BlogIcon.svelte'
+	import GitHubIcon from '$lib/icons/GitHubIcon.svelte'
+	import LiveDemoIcon from '$lib/icons/LiveDemoIcon.svelte'
+	import PackageIcon from '$lib/icons/PackageIcon.svelte'
+	import type { ProjectLink } from '$lib/types/project'
+
+	const { type, size } = $props<{
+		type: ProjectLink['type']
+		size: string
+	}>()
+</script>
+
+{#if type === 'blog'}
+	<BlogIcon {size} />
+{:else if type === 'github'}
+	<GitHubIcon {size} />
+{:else if type === 'npm'}
+	<PackageIcon {size} />
+{:else if type === 'demo'}
+	<LiveDemoIcon {size} />
+{/if}

--- a/src/lib/components/ProjectCardLinkButton.svelte
+++ b/src/lib/components/ProjectCardLinkButton.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
 	import { app } from '$lib/app'
+	import LinkTypeIcon from '$lib/components/LinkTypeIcon.svelte'
 	import { PROJECT_CARD_LINK_BUTTON_CLASS } from '$lib/constants/card-styles'
 	import { ICON_SIZE_SM } from '$lib/constants/layout'
-	import BlogIcon from '$lib/icons/BlogIcon.svelte'
-	import GitHubIcon from '$lib/icons/GitHubIcon.svelte'
-	import PackageIcon from '$lib/icons/PackageIcon.svelte'
 	import type { ProjectLink } from '$lib/types/project'
 	import { link_utilities } from '$lib/utils/link-utilities'
 
@@ -19,12 +17,6 @@
 	rel={link_info.rel}
 	class={PROJECT_CARD_LINK_BUTTON_CLASS}
 >
-	{#if link.type === 'blog'}
-		<BlogIcon size={ICON_SIZE_SM} />
-	{:else if link.type === 'github'}
-		<GitHubIcon size={ICON_SIZE_SM} />
-	{:else if link.type === 'npm'}
-		<PackageIcon size={ICON_SIZE_SM} />
-	{/if}
+	<LinkTypeIcon type={link.type} size={ICON_SIZE_SM} />
 	{app.link_label(link.type)}
 </a>

--- a/src/lib/components/ProjectLinks.svelte
+++ b/src/lib/components/ProjectLinks.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { app, LINK_REL, LINK_TARGET } from '$lib/app'
+	import LinkTypeIcon from '$lib/components/LinkTypeIcon.svelte'
 	import { ICON_SIZE_SM, LINK_BASE_DEFAULT_CLASS } from '$lib/constants/layout'
-	import GitHubIcon from '$lib/icons/GitHubIcon.svelte'
-	import LiveDemoIcon from '$lib/icons/LiveDemoIcon.svelte'
 	import type { ProjectLink } from '$lib/types/project'
 
 	const { links } = $props<{
@@ -18,11 +17,7 @@
 			rel={LINK_REL}
 			class="{LINK_BASE_DEFAULT_CLASS} flex items-center gap-2"
 		>
-			{#if link.type === 'github'}
-				<GitHubIcon size={ICON_SIZE_SM} />
-			{:else if link.type === 'demo'}
-				<LiveDemoIcon size={ICON_SIZE_SM} />
-			{/if}
+			<LinkTypeIcon type={link.type} size={ICON_SIZE_SM} />
 			{app.link_label(link.type)}
 		</a>
 	{/each}

--- a/src/lib/constants/interactive-effects.spec.ts
+++ b/src/lib/constants/interactive-effects.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import { INTERACTIVE_SCALE_HOVER } from './interactive-effects'
 import {
 	MENU_TOGGLE_BUTTON_CLASSES,
+	NAV_ICON_SIZE,
 	SOCIAL_LINK_DESKTOP_CLASSES,
 	SOCIAL_LINK_MOBILE_CLASSES,
 } from './sticky-header-constants'
@@ -14,6 +15,10 @@ const CONSUMER_CASES: ReadonlyArray<readonly [string, string]> = [
 
 test('INTERACTIVE_SCALE_HOVER resolves to the shared Tailwind tokens', () => {
 	expect(INTERACTIVE_SCALE_HOVER).toBe('hover:scale-110 active:scale-95')
+})
+
+test('NAV_ICON_SIZE matches ICON_SIZE_MD value', () => {
+	expect(NAV_ICON_SIZE).toBe('1.25rem')
 })
 
 test.each(CONSUMER_CASES)('%s includes INTERACTIVE_SCALE_HOVER exactly once', (_name, value) => {

--- a/src/lib/constants/interactive-effects.spec.ts
+++ b/src/lib/constants/interactive-effects.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { INTERACTIVE_SCALE_HOVER } from './interactive-effects'
+import { ICON_SIZE_MD } from './layout'
 import {
 	MENU_TOGGLE_BUTTON_CLASSES,
 	NAV_ICON_SIZE,
@@ -18,7 +19,7 @@ test('INTERACTIVE_SCALE_HOVER resolves to the shared Tailwind tokens', () => {
 })
 
 test('NAV_ICON_SIZE matches ICON_SIZE_MD value', () => {
-	expect(NAV_ICON_SIZE).toBe('1.25rem')
+	expect(NAV_ICON_SIZE).toBe(ICON_SIZE_MD)
 })
 
 test.each(CONSUMER_CASES)('%s includes INTERACTIVE_SCALE_HOVER exactly once', (_name, value) => {

--- a/src/lib/constants/sticky-header-constants.ts
+++ b/src/lib/constants/sticky-header-constants.ts
@@ -1,3 +1,4 @@
+import { ICON_SIZE_MD } from '$lib/constants/layout'
 import { INTERACTIVE_SCALE_HOVER } from './interactive-effects'
 
 const MENU_WIDTH = 280
@@ -10,7 +11,7 @@ const HEADER_LEFT_SECTION_CLASSES = 'flex min-w-0 flex-1 items-center gap-4 md:g
 const HEADER_RIGHT_SECTION_CLASSES = 'flex shrink-0 items-center gap-2'
 const HEADER_HEIGHT = '4rem'
 const HEADER_HEIGHT_PX = 64
-const NAV_ICON_SIZE = '1.25rem'
+const NAV_ICON_SIZE = ICON_SIZE_MD
 
 const MENU_NAV_DESKTOP_BASE =
 	'cyber-glow-hover group relative flex items-center gap-2 rounded-lg px-3 py-2 text-base font-medium'

--- a/src/lib/constants/typography.spec.ts
+++ b/src/lib/constants/typography.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest'
+import { SECTION_ICON_SIZE } from './typography'
+
+test('SECTION_ICON_SIZE matches ICON_SIZE_MD value', () => {
+	expect(SECTION_ICON_SIZE).toBe('1.25rem')
+})

--- a/src/lib/constants/typography.spec.ts
+++ b/src/lib/constants/typography.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
+import { ICON_SIZE_MD } from './layout'
 import { SECTION_ICON_SIZE } from './typography'
 
 test('SECTION_ICON_SIZE matches ICON_SIZE_MD value', () => {
-	expect(SECTION_ICON_SIZE).toBe('1.25rem')
+	expect(SECTION_ICON_SIZE).toBe(ICON_SIZE_MD)
 })

--- a/src/lib/constants/typography.ts
+++ b/src/lib/constants/typography.ts
@@ -1,8 +1,10 @@
+import { ICON_SIZE_MD } from '$lib/constants/layout'
+
 const SECTION_HEADING_LIGHT_LG_CLASS = 'text-3xl font-light tracking-tight text-white/90'
 
 const SECTION_HEADING_LIGHT_SM_CLASS = 'text-2xl font-light tracking-tight text-white/90'
 
-const SECTION_ICON_SIZE = '1.25rem'
+const SECTION_ICON_SIZE = ICON_SIZE_MD
 
 const SECTION_ICON_WRAPPER_CLASS =
 	'flex items-center justify-center rounded-xl border border-sky-400/30 bg-sky-500/10 p-2 text-sky-400 shadow-[0_0_15px_rgba(56,189,248,0.2)] ring-1 ring-sky-400/20 ring-inset'


### PR DESCRIPTION
## Summary
- Created `LinkTypeIcon.svelte` unifying blog/github/npm/demo icon mapping; updated `ProjectCardLinkButton` and `ProjectLinks` to use it
- Removed duplicate `'1.25rem'` literals: `SECTION_ICON_SIZE` and `NAV_ICON_SIZE` now reference `ICON_SIZE_MD` from `layout.ts`
- Added unit tests for `SECTION_ICON_SIZE` and `NAV_ICON_SIZE` alignment

## Test plan
- [x] Unit: `typography.spec.ts` — `SECTION_ICON_SIZE` equals `ICON_SIZE_MD` value
- [x] Unit: `interactive-effects.spec.ts` — `NAV_ICON_SIZE` equals `ICON_SIZE_MD` value
- [x] E2E: existing `projects.test.ts` covers icon rendering in project cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)