### PR TITLE
Docs: allow arrow functions for Svelte Action type assignments #522

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Stack: TypeScript · pnpm · SvelteKit · Vitest · Playwright · TailwindCSS ·
 - `$state` reactive variables are reassignable
 - Props interface name `Props` is allowed by ESLint
 - DOM manipulation is restricted
+- Exception: `const foo: Action = ...` arrow-function assignments are allowed for Svelte actions (typed with `Action` from `svelte/action`); converting to a plain `function` declaration would lose the type annotation
 
 ### Content rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Stack: TypeScript · pnpm · SvelteKit · Vitest · Playwright · TailwindCSS ·
 - `$state` reactive variables are reassignable
 - Props interface name `Props` is allowed by ESLint
 - DOM manipulation is restricted
+- Exception: `const foo: Action = ...` arrow-function assignments are allowed for Svelte actions (typed with `Action` from `svelte/action`); converting to a plain `function` declaration would lose the type annotation
 
 ### Content rules
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -38,6 +38,7 @@ Stack: TypeScript · pnpm · SvelteKit · Vitest · Playwright · TailwindCSS ·
 - `$state` reactive variables are reassignable
 - Props interface name `Props` is allowed by ESLint
 - DOM manipulation is restricted
+- Exception: `const foo: Action = ...` arrow-function assignments are allowed for Svelte actions (typed with `Action` from `svelte/action`); converting to a plain `function` declaration would lose the type annotation
 
 ### Content rules
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.191.0",
+	"version": "0.192.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.1+sha512.05ba3c1d5d1c18f68df06470d74055e62d41fc110a0c660db1b2dfb2785327f04cf0f68345d4609bc52089e7fa0343c31593b2f9594e2c5d5da426230acc9820",
 	"engines": {


### PR DESCRIPTION
closes #522