### PR TITLE
Codebase quality: add unit tests for security, project-card-layout, and project-utilities #523

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.192.0",
+	"version": "0.193.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.1+sha512.05ba3c1d5d1c18f68df06470d74055e62d41fc110a0c660db1b2dfb2785327f04cf0f68345d4609bc52089e7fa0343c31593b2f9594e2c5d5da426230acc9820",
 	"engines": {

--- a/src/lib/server/security.test.ts
+++ b/src/lib/server/security.test.ts
@@ -1,0 +1,189 @@
+import { RATE_LIMIT_COUNT } from '$lib/constants/security'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { security } from './security'
+
+vi.mock('$lib/logger', () => ({
+	logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}))
+
+const APP_ID = 'joshuafolkken-com'
+const BASE_URL = 'https://joshuafolkken.com/api/test'
+const SAME_ORIGIN = 'https://joshuafolkken.com'
+const DIFFERENT_ORIGIN = 'https://evil.example.com'
+const LOCALHOST_ORIGIN = 'http://localhost:5173'
+const INVALID_ORIGIN = 'not-a-url'
+
+let ip_counter = 0
+
+function unique_ip(): string {
+	ip_counter += 1
+
+	return `10.99.0.${String(ip_counter)}`
+}
+
+function make_request(options: { origin?: string; client?: string } = {}): Request {
+	const headers = new Headers({ 'X-App-Client': APP_ID })
+
+	if (options.origin !== undefined) headers.set('origin', options.origin)
+	if (options.client !== undefined) headers.set('X-App-Client', options.client)
+
+	return new Request(BASE_URL, { headers })
+}
+
+const APP_URL = new URL(BASE_URL)
+
+beforeEach(() => {
+	vi.clearAllMocks()
+})
+
+describe('security.add_security_headers', () => {
+	it('sets X-Content-Type-Options to nosniff', () => {
+		const response = new Response()
+
+		security.add_security_headers(response)
+
+		expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+	})
+
+	it('sets X-Frame-Options to SAMEORIGIN', () => {
+		const response = new Response()
+
+		security.add_security_headers(response)
+
+		expect(response.headers.get('X-Frame-Options')).toBe('SAMEORIGIN')
+	})
+
+	it('sets Referrer-Policy to strict-origin-when-cross-origin', () => {
+		const response = new Response()
+
+		security.add_security_headers(response)
+
+		expect(response.headers.get('Referrer-Policy')).toBe('strict-origin-when-cross-origin')
+	})
+})
+
+describe('security.json_error', () => {
+	const FORBIDDEN_MESSAGE = 'Forbidden'
+
+	it('returns a response with the given HTTP status', () => {
+		const response = security.json_error(FORBIDDEN_MESSAGE, 403)
+
+		expect(response.status).toBe(403)
+	})
+
+	it('includes the error message in the JSON body', async () => {
+		const response = security.json_error(FORBIDDEN_MESSAGE, 403)
+		const body = await response.json()
+
+		expect(body).toEqual({ error: FORBIDDEN_MESSAGE })
+	})
+})
+
+describe('security.validate_request_security — rate limit', () => {
+	it('allows requests under the limit', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(make_request(), APP_URL, ip)
+
+		expect(result).toBeUndefined()
+	})
+
+	it('blocks the request after exceeding the rate limit', () => {
+		const ip = unique_ip()
+		const request = make_request()
+
+		for (let index = 0; index < RATE_LIMIT_COUNT; index++) {
+			security.validate_request_security(request, APP_URL, ip)
+		}
+
+		const result = security.validate_request_security(request, APP_URL, ip)
+
+		expect(result).toBeInstanceOf(Response)
+		expect(result?.status).toBe(429)
+	})
+})
+
+describe('security.validate_request_security — custom header', () => {
+	it('returns undefined when the correct app client header is present', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(make_request(), APP_URL, ip)
+
+		expect(result).toBeUndefined()
+	})
+
+	it('returns 403 when the app client header is missing', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(make_request({ client: '' }), APP_URL, ip)
+
+		expect(result).toBeInstanceOf(Response)
+		expect(result?.status).toBe(403)
+	})
+
+	it('returns 403 when the app client header has an incorrect value', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(
+			make_request({ client: 'wrong-client' }),
+			APP_URL,
+			ip,
+		)
+
+		expect(result).toBeInstanceOf(Response)
+		expect(result?.status).toBe(403)
+	})
+})
+
+describe('security.validate_request_security — origin (allowed)', () => {
+	it('returns undefined when no origin header is present', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(make_request(), APP_URL, ip)
+
+		expect(result).toBeUndefined()
+	})
+
+	it('returns undefined when origin matches the request URL', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(
+			make_request({ origin: SAME_ORIGIN }),
+			APP_URL,
+			ip,
+		)
+
+		expect(result).toBeUndefined()
+	})
+
+	it('returns undefined when origin is localhost', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(
+			make_request({ origin: LOCALHOST_ORIGIN }),
+			APP_URL,
+			ip,
+		)
+
+		expect(result).toBeUndefined()
+	})
+})
+
+describe('security.validate_request_security — origin (blocked)', () => {
+	it('returns 403 when origin does not match the request URL', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(
+			make_request({ origin: DIFFERENT_ORIGIN }),
+			APP_URL,
+			ip,
+		)
+
+		expect(result).toBeInstanceOf(Response)
+		expect(result?.status).toBe(403)
+	})
+
+	it('returns 403 when origin is not a valid URL', () => {
+		const ip = unique_ip()
+		const result = security.validate_request_security(
+			make_request({ origin: INVALID_ORIGIN }),
+			APP_URL,
+			ip,
+		)
+
+		expect(result).toBeInstanceOf(Response)
+		expect(result?.status).toBe(403)
+	})
+})

--- a/src/lib/utils/project-card-layout.test.ts
+++ b/src/lib/utils/project-card-layout.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { get_card_body_padding, get_demo_tag_row_class } from './project-card-layout'
+
+describe('get_card_body_padding', () => {
+	describe('when should_include_tags is true', () => {
+		it('returns clearance padding when has_secondary_link is true', () => {
+			expect(get_card_body_padding(true, true, false)).toBe('pb-16')
+		})
+
+		it('returns empty string when has_secondary_link is false', () => {
+			expect(get_card_body_padding(true, false, false)).toBe('')
+		})
+
+		it('ignores has_tag_list when tags are included inside', () => {
+			expect(get_card_body_padding(true, false, true)).toBe('')
+		})
+	})
+
+	describe('when should_include_tags is false', () => {
+		it('returns before-external-tags padding when has_tag_list is true', () => {
+			expect(get_card_body_padding(false, false, true)).toBe('pb-2')
+		})
+
+		it('returns clearance padding when has_secondary_link is true and no tag list', () => {
+			expect(get_card_body_padding(false, true, false)).toBe('pb-16')
+		})
+
+		it('returns section-default padding when no secondary link and no tag list', () => {
+			expect(get_card_body_padding(false, false, false)).toBe('pb-6')
+		})
+	})
+})
+
+describe('get_demo_tag_row_class', () => {
+	it('includes clearance padding when has_secondary_link is true', () => {
+		expect(get_demo_tag_row_class(true)).toBe('px-6 pb-16')
+	})
+
+	it('includes section-default padding when has_secondary_link is false', () => {
+		expect(get_demo_tag_row_class(false)).toBe('px-6 pb-6')
+	})
+})

--- a/src/lib/utils/project-utilities.test.ts
+++ b/src/lib/utils/project-utilities.test.ts
@@ -1,0 +1,61 @@
+import type { Project, ProjectLink } from '$lib/types/project'
+import { describe, expect, it } from 'vitest'
+import { project_utilities } from './project-utilities'
+
+const GITHUB_HREF = 'https://github.com/example'
+const DEMO_HREF = 'https://example.com/demo'
+const DEMO_HREF_SHORT = 'https://example.com'
+const NPM_HREF = 'https://npmjs.com/example'
+
+function make_link(type: ProjectLink['type'], href: string): ProjectLink {
+	return { type, href }
+}
+
+function make_project(links: Array<ProjectLink>): Project {
+	return { title: 'Test', description: 'Test', links } as unknown as Project
+}
+
+describe('project_utilities.get_demo_href', () => {
+	it('returns the href of the demo link when one exists', () => {
+		const project = make_project([make_link('demo', DEMO_HREF), make_link('github', GITHUB_HREF)])
+
+		expect(project_utilities.get_demo_href(project)).toBe(DEMO_HREF)
+	})
+
+	it('returns undefined when no demo link exists', () => {
+		const project = make_project([make_link('github', GITHUB_HREF)])
+
+		expect(project_utilities.get_demo_href(project)).toBeUndefined()
+	})
+
+	it('returns undefined when links array is empty', () => {
+		expect(project_utilities.get_demo_href(make_project([]))).toBeUndefined()
+	})
+})
+
+describe('project_utilities.get_secondary_links', () => {
+	it('returns all non-demo links', () => {
+		const github = make_link('github', GITHUB_HREF)
+		const npm = make_link('npm', NPM_HREF)
+		const project = make_project([make_link('demo', DEMO_HREF_SHORT), github, npm])
+
+		expect(project_utilities.get_secondary_links(project)).toEqual([github, npm])
+	})
+
+	it('returns all links when there is no demo link', () => {
+		const github = make_link('github', GITHUB_HREF)
+		const project = make_project([github])
+
+		expect(project_utilities.get_secondary_links(project)).toEqual([github])
+	})
+
+	it('returns an empty array when all links are demo links', () => {
+		const project = make_project([make_link('demo', DEMO_HREF_SHORT)])
+
+		expect(project_utilities.get_secondary_links(project)).toEqual([])
+	})
+
+	it('returns an empty array when links array is empty', () => {
+		expect(project_utilities.get_secondary_links(make_project([]))).toEqual([])
+	})
+})


### PR DESCRIPTION
## Summary

- Add `src/lib/server/security.test.ts` — covers `add_security_headers`, `json_error`, rate limiting, custom-header validation, and origin validation (allowed + blocked cases)
- Add `src/lib/utils/project-card-layout.test.ts` — covers `get_card_body_padding` (6 combinations) and `get_demo_tag_row_class` (2 cases)
- Add `src/lib/utils/project-utilities.test.ts` — covers `get_demo_href` and `get_secondary_links`

## Scope notes

- **Change 2 (return types)**: all functions in `project-card-layout.ts` already had explicit `: string` annotations — no code change needed.
- **Change 1 (i18n)**: Paraglide is not in `package.json`; the entire site uses hardcoded English. Retrofitting would require installing Paraglide and updating all pages — tracked separately.
- **Change 5 (large components)**: `about/+page.svelte` (207 lines) and `privacy/+page.svelte` (260 lines) are both within the 300-line limit — no refactoring required.

## Test plan

- [x] `pnpm josh lint` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm josh cspell:dot` — clean
- [x] `pnpm josh test:unit` — 32 files, 231 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)