### PR TITLE
Refactor SocialShareButton: static config lookup + extract icon components #547

### DIFF
--- a/e2e/social-share-button.spec.ts
+++ b/e2e/social-share-button.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test'
+import { TEST_ROUTES } from './test-routes'
+
+const TWITTER_SHARE_URL_PREFIX = 'https://twitter.com/intent/tweet'
+const TWITTER_ARIA_LABEL = 'Share on X'
+
+test.describe('SocialShareButton', () => {
+	test('renders Twitter share link pointing to twitter.com with current page URL', async ({
+		page,
+	}) => {
+		await page.goto(TEST_ROUTES.BLOG_POST)
+
+		const share_link = page.getByRole('link', { name: TWITTER_ARIA_LABEL })
+
+		await expect(share_link).toBeVisible()
+
+		const href = await share_link.getAttribute('href')
+
+		expect(href).toMatch(new RegExp(`^${TWITTER_SHARE_URL_PREFIX}`, 'u'))
+		expect(href).toContain(encodeURIComponent(TEST_ROUTES.BLOG_POST))
+	})
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.203.0",
+	"version": "0.204.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
 	"engines": {

--- a/src/lib/components/SocialShareButton.svelte
+++ b/src/lib/components/SocialShareButton.svelte
@@ -2,9 +2,17 @@
 	import { page } from '$app/state'
 	import { LINK_REL, LINK_TARGET } from '$lib/app'
 	import { SOCIAL_BUTTONS } from '$lib/constants/social-buttons'
+	import FacebookIcon from '$lib/icons/FacebookIcon.svelte'
+	import XIcon from '$lib/icons/XIcon.svelte'
 	import { share_url_utilities } from '$lib/utils/share-url-utilities'
 
 	type ShareType = 'facebook' | 'twitter'
+
+	interface ShareConfig {
+		hover_class: string
+		aria_label: string
+		icon_size: string
+	}
 
 	interface Props {
 		type: ShareType
@@ -12,62 +20,40 @@
 		class?: string
 	}
 
+	const SHARE_CONFIG = {
+		facebook: {
+			hover_class: SOCIAL_BUTTONS.FACEBOOK_HOVER,
+			aria_label: 'Share on Facebook',
+			icon_size: '1.5rem',
+		},
+		twitter: {
+			hover_class: SOCIAL_BUTTONS.TWITTER_HOVER,
+			aria_label: 'Share on X',
+			icon_size: '1.25rem',
+		},
+	} as const satisfies Record<ShareType, ShareConfig>
+
 	const { type, title = '', class: class_name = '' }: Props = $props()
 
 	const url = $derived(page.url.toString())
-
-	const href = $derived.by(() => {
-		if (type === 'facebook') {
-			return share_url_utilities.build_facebook_share_url(url)
-		}
-
-		return share_url_utilities.build_twitter_share_url(url, title)
-	})
-
-	const hover_class = $derived(
-		type === 'facebook' ? SOCIAL_BUTTONS.FACEBOOK_HOVER : SOCIAL_BUTTONS.TWITTER_HOVER,
+	const config = $derived(SHARE_CONFIG[type])
+	const href = $derived(
+		type === 'facebook'
+			? share_url_utilities.build_facebook_share_url(url)
+			: share_url_utilities.build_twitter_share_url(url, title),
 	)
-
-	const { aria_label, svg_path, view_box, icon_class, svg_width, svg_height } = $derived.by(() => {
-		if (type === 'facebook') {
-			return {
-				aria_label: 'Share on Facebook',
-				svg_path:
-					'M9.198 21.5h4v-8.01h3.604l.396-3.98h-4V7.5a1 1 0 0 1 1-1h3v-4h-3a5 5 0 0 0-5 5v2.01h-2l-.396 3.98h2.396v8.01Z',
-				view_box: '0 0 24 24',
-				icon_class: 'h-6 w-6',
-				svg_width: '24',
-				svg_height: '24',
-			}
-		}
-
-		return {
-			aria_label: 'Share on X',
-			svg_path:
-				'M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z',
-			view_box: '0 0 24 24',
-			icon_class: 'h-5 w-5',
-			svg_width: '16',
-			svg_height: '16',
-		}
-	})
 </script>
 
 <a
 	{href}
 	target={LINK_TARGET}
 	rel={LINK_REL}
-	class="{SOCIAL_BUTTONS.BASE} {hover_class} {class_name}"
-	aria-label={aria_label}
+	class="{SOCIAL_BUTTONS.BASE} {config.hover_class} {class_name}"
+	aria-label={config.aria_label}
 >
-	<svg
-		xmlns="http://www.w3.org/2000/svg"
-		width={svg_width}
-		height={svg_height}
-		viewBox={view_box}
-		fill="currentColor"
-		class={icon_class}
-	>
-		<path d={svg_path}></path>
-	</svg>
+	{#if type === 'facebook'}
+		<FacebookIcon size={config.icon_size} />
+	{:else}
+		<XIcon size={config.icon_size} />
+	{/if}
 </a>

--- a/src/lib/icons/FacebookIcon.svelte
+++ b/src/lib/icons/FacebookIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import BaseIcon from '$lib/icons/BaseIcon.svelte'
+
+	const {
+		size = '1.5rem',
+		title = 'Facebook',
+		aria_label,
+	} = $props<{
+		size?: string
+		title?: string
+		aria_label?: string
+	}>()
+</script>
+
+<BaseIcon {size} {title} {aria_label} fill="currentColor" stroke="none">
+	<path
+		d="M9.198 21.5h4v-8.01h3.604l.396-3.98h-4V7.5a1 1 0 0 1 1-1h3v-4h-3a5 5 0 0 0-5 5v2.01h-2l-.396 3.98h2.396v8.01Z"
+	></path>
+</BaseIcon>


### PR DESCRIPTION
Closes #547

## Changes
- Replace complex `$derived.by()` with `SHARE_CONFIG` static lookup map (`as const satisfies`)
- Create `FacebookIcon.svelte` following existing `BaseIcon` pattern
- Use `FacebookIcon` / `XIcon` components instead of inline SVGs
- Add E2E test verifying Twitter share link href on blog post page

## Test plan
- [x] Unit tests: 286 passed
- [x] E2E tests: 91 passed (local)