### PR TITLE
Standardize data array typing: use as const satisfies ReadonlyArray #549

### DIFF
--- a/e2e/copy-button.spec.ts
+++ b/e2e/copy-button.spec.ts
@@ -4,8 +4,6 @@ import { TEST_ROUTES } from './test-routes'
 const COPY_BUTTON_ARIA_LABEL = 'Copy Link'
 const COPIED_TEXT = 'Copied!'
 
-test.use({ permissions: ['clipboard-read', 'clipboard-write'] })
-
 test.describe('CopyButton', () => {
 	test('renders Copy Link button on blog post page', async ({ page }) => {
 		await page.goto(TEST_ROUTES.BLOG_POST)
@@ -16,6 +14,20 @@ test.describe('CopyButton', () => {
 	})
 
 	test('shows copied state after clicking', async ({ page }) => {
+		// Mock clipboard API before page loads to ensure deterministic behavior
+		// across environments (macOS vs Linux CI differ in clipboard access).
+		await page.addInitScript(() => {
+			Object.defineProperty(navigator, 'clipboard', {
+				value: {
+					writeText: async () => {
+						await Promise.resolve()
+					},
+				},
+				writable: true,
+				configurable: true,
+			})
+		})
+
 		await page.goto(TEST_ROUTES.BLOG_POST)
 
 		const copy_button = page.getByRole('button', { name: COPY_BUTTON_ARIA_LABEL })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.205.0",
+	"version": "0.206.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
 	"engines": {

--- a/src/lib/components/ProjectList.svelte
+++ b/src/lib/components/ProjectList.svelte
@@ -3,7 +3,7 @@
 	import ProjectCard from './ProjectCard.svelte'
 
 	const { projects } = $props<{
-		projects: Array<Project>
+		projects: ReadonlyArray<Project>
 	}>()
 </script>
 

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -32,7 +32,7 @@ const KIT_BLOG_URL = '/blog/kit-package'
 
 const FEATURED_COUNT = 4
 
-export const PROJECTS: Array<Project> = [
+export const PROJECTS = [
 	{
 		icon: PackageIcon,
 		title: '@joshuafolkken/kit',
@@ -166,6 +166,6 @@ export const PROJECTS: Array<Project> = [
 		image: godot_multiplayer,
 		tags: [GODOT, GDSCRIPT, 'WebSockets', WEB_EXPORT],
 	},
-]
+] as const satisfies ReadonlyArray<Project>
 
 export const FEATURED_PROJECTS = PROJECTS.slice(0, FEATURED_COUNT)

--- a/src/lib/data/skills.ts
+++ b/src/lib/data/skills.ts
@@ -5,7 +5,7 @@ export interface Skill {
 	percent: number
 }
 
-export const SKILLS: Array<Skill> = [
+export const SKILLS = [
 	{ name: 'Teaching & Mentoring', percent: 85 },
 	{ name: 'SvelteKit', percent: 85 },
 	{ name: 'TypeScript', percent: 85 },
@@ -18,4 +18,4 @@ export const SKILLS: Array<Skill> = [
 	{ name: 'Community Building', percent: 60 },
 	{ name: 'Rust', percent: 50 },
 	{ name: 'Game Design', percent: 30 },
-]
+] as const satisfies ReadonlyArray<Skill>

--- a/src/lib/data/social-links.ts
+++ b/src/lib/data/social-links.ts
@@ -12,13 +12,13 @@ interface SocialLink {
 	label?: string
 }
 
-const HEADER_SOCIAL_LINKS: Array<SocialLink> = [
+const HEADER_SOCIAL_LINKS = [
 	{ href: URLS.GITHUB, aria_label: 'GitHub', icon: GitHubIcon, is_external: true },
 	{ href: URLS.X, aria_label: 'X', icon: XIcon, is_external: true },
 	{ href: URLS.YOUTUBE, aria_label: 'YouTube', icon: YouTubeIcon, is_external: true },
-]
+] as const satisfies ReadonlyArray<SocialLink>
 
-const CONTACT_SOCIAL_LINKS: Array<SocialLink> = [
+const CONTACT_SOCIAL_LINKS = [
 	{ href: URLS.X, aria_label: 'X', icon: XIcon, is_external: true, label: 'X (Twitter)' },
 	{ href: URLS.GITHUB, aria_label: 'GitHub', icon: GitHubIcon, is_external: true, label: 'GitHub' },
 	{
@@ -28,7 +28,7 @@ const CONTACT_SOCIAL_LINKS: Array<SocialLink> = [
 		is_external: true,
 		label: 'YouTube',
 	},
-]
+] as const satisfies ReadonlyArray<SocialLink>
 
 export type { SocialLink }
 export { CONTACT_SOCIAL_LINKS, HEADER_SOCIAL_LINKS }


### PR DESCRIPTION
## Summary
- Apply `as const satisfies ReadonlyArray<T>` to `projects.ts`, `social-links.ts`, and `skills.ts` to preserve literal types and prevent mutation
- Update `ProjectList.svelte` prop from `Array<Project>` to `ReadonlyArray<Project>` to accept the readonly source data
- Fix `copy-button.spec.ts` E2E test to use `addInitScript` clipboard mock for cross-platform reliability (macOS vs Linux CI)

## Test plan
- [x] `pnpm josh lint` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm josh cspell:dot` — clean
- [x] `pnpm josh test:unit` — 288/288 pass
- [ ] E2E: awaiting CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)