### PR TITLE
Constants cleanup: name intersection threshold + consolidate CONTENT_TYPE #550

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "joshuafolkken-com",
 	"private": true,
-	"version": "0.206.0",
+	"version": "0.207.0",
 	"type": "module",
 	"packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
 	"engines": {

--- a/src/lib/actions/intersection-observer.ts
+++ b/src/lib/actions/intersection-observer.ts
@@ -1,5 +1,7 @@
 import type { Action } from 'svelte/action'
 
+const INTERSECTION_THRESHOLD = 0
+
 /* eslint-disable promise/prefer-await-to-callbacks */
 const intersect: Action<HTMLElement, (() => void) | undefined> = (node, callback) => {
 	const observer = new IntersectionObserver(
@@ -11,7 +13,7 @@ const intersect: Action<HTMLElement, (() => void) | undefined> = (node, callback
 				observer.disconnect()
 			}
 		},
-		{ threshold: 0 },
+		{ threshold: INTERSECTION_THRESHOLD },
 	)
 
 	observer.observe(node)

--- a/src/lib/api/like-api.ts
+++ b/src/lib/api/like-api.ts
@@ -1,5 +1,5 @@
 import { APP } from '$lib/app'
-import { CONTENT_TYPE_JSON, ERROR_MESSAGES, HTTP_HEADERS } from '$lib/constants/http'
+import { CONTENT_TYPE, ERROR_MESSAGES, HTTP_HEADERS } from '$lib/constants/http'
 
 interface LikeResponse {
 	likes: number
@@ -46,7 +46,7 @@ async function increment(slug: string): Promise<LikeResponse> {
 	const response = await fetch('/api/like', {
 		method: 'POST',
 		headers: {
-			[HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPE_JSON,
+			[HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPE.JSON,
 			[HTTP_HEADERS.X_APP_CLIENT]: APP.ID,
 		},
 		body: JSON.stringify({ slug }),

--- a/src/lib/api/opencollective-api.ts
+++ b/src/lib/api/opencollective-api.ts
@@ -1,5 +1,5 @@
 import { OPENCOLLECTIVE } from '$lib/app'
-import { CONTENT_TYPE_JSON, ERROR_MESSAGES, HTTP_HEADERS } from '$lib/constants/http'
+import { CONTENT_TYPE, ERROR_MESSAGES, HTTP_HEADERS } from '$lib/constants/http'
 import type {
 	GraphqlContributor,
 	GraphqlResponse,
@@ -94,7 +94,7 @@ async function fetch_supporters(
 ): Promise<Array<OpenCollectiveMember>> {
 	const response = await fetch_function(GRAPHQL_ENDPOINT, {
 		method: 'POST',
-		headers: { [HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPE_JSON },
+		headers: { [HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPE.JSON },
 		body: JSON.stringify({
 			query: CONTRIBUTORS_QUERY,
 			variables: { slug: OPENCOLLECTIVE.SLUG, limit: CONTRIBUTORS_LIMIT },

--- a/src/lib/constants/http.ts
+++ b/src/lib/constants/http.ts
@@ -27,5 +27,7 @@ export const HTTP_HEADERS = {
 	X_APP_CLIENT: 'X-App-Client',
 } as const
 
-export const CONTENT_TYPE_JSON = 'application/json' as const
-export const CONTENT_TYPE_XML = 'application/xml' as const
+export const CONTENT_TYPE = {
+	JSON: 'application/json',
+	XML: 'application/xml',
+} as const

--- a/src/routes/api/like/+server.ts
+++ b/src/routes/api/like/+server.ts
@@ -1,5 +1,5 @@
 import { json } from '@sveltejs/kit'
-import { CONTENT_TYPE_JSON, ERROR_MESSAGES, HTTP_HEADERS, HTTP_STATUS } from '$lib/constants/http'
+import { CONTENT_TYPE, ERROR_MESSAGES, HTTP_HEADERS, HTTP_STATUS } from '$lib/constants/http'
 import { logger } from '$lib/logger'
 import { like_store } from '$lib/server/like-store'
 import { security, type SecurityContext } from '$lib/server/security'
@@ -13,7 +13,7 @@ interface LikeRequestBody {
 function is_json_content_type(request: Request): boolean {
 	const content_type = request.headers.get(HTTP_HEADERS.CONTENT_TYPE)
 
-	return content_type?.startsWith(CONTENT_TYPE_JSON) ?? false
+	return content_type?.startsWith(CONTENT_TYPE.JSON) ?? false
 }
 
 function is_like_request_body(value: unknown): value is LikeRequestBody {

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,5 +1,5 @@
 import { APP } from '$lib/app'
-import { CONTENT_TYPE_XML, HTTP_HEADERS } from '$lib/constants/http'
+import { CONTENT_TYPE, HTTP_HEADERS } from '$lib/constants/http'
 import {
 	SITEMAP_CACHE_MAX_AGE_SECONDS,
 	SITEMAP_CHANGEFREQ,
@@ -93,7 +93,7 @@ ${url_xml}
 	return new Response(sitemap_xml, {
 		headers: {
 			[HTTP_HEADERS.CACHE_CONTROL]: `public, max-age=${String(SITEMAP_CACHE_MAX_AGE_SECONDS)}`,
-			[HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPE_XML,
+			[HTTP_HEADERS.CONTENT_TYPE]: CONTENT_TYPE.XML,
 		},
 	})
 }


### PR DESCRIPTION
## Summary
- Added `INTERSECTION_THRESHOLD = 0` constant in `intersection-observer.ts` to replace magic number
- Consolidated `CONTENT_TYPE_JSON` / `CONTENT_TYPE_XML` into a single `CONTENT_TYPE` object in `http.ts`
- Updated all 4 import sites (`opencollective-api.ts`, `like-api.ts`, `routes/api/like/+server.ts`, `routes/sitemap.xml/+server.ts`) to use `CONTENT_TYPE.JSON` / `CONTENT_TYPE.XML`

## Test plan
- [ ] Unit tests pass (288/288)
- [ ] Lint passes
- [ ] TypeScript type-check passes
- [ ] No functional behavior changes — purely constants cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)