### PR TITLE
linkify urls and markdown links inside inline code backticks #705

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "joshuafolkken-com",
-	"version": "0.277.0",
+	"version": "0.278.0",
 	"type": "module",
 	"private": true,
 	"scripts": {

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -5,6 +5,8 @@ import { markdown } from './markdown'
 const LINK_URL = 'https://example.com'
 const CODE_QUEUE_HTML = '<code>queue</code>'
 const STRONG_KIT_HTML = '<strong>kit</strong>'
+const TARGET_BLANK = 'target="_blank"'
+const REL_NOOPENER = 'rel="noopener noreferrer"'
 
 describe('markdown.to_html', () => {
 	it('renders inline code without literal backticks', () => {
@@ -52,12 +54,38 @@ describe('markdown.to_html links', () => {
 
 		expect(html).toContain(`href="${LINK_URL}"`)
 		expect(html).toContain('>docs</a>')
-		expect(html).toContain('target="_blank"')
-		expect(html).toContain('rel="noopener noreferrer"')
+		expect(html).toContain(TARGET_BLANK)
+		expect(html).toContain(REL_NOOPENER)
 	})
 
 	it('autolinks a bare url', () => {
 		expect(markdown.to_html(`see ${LINK_URL}`)).toContain(`href="${LINK_URL}"`)
+	})
+})
+
+describe('markdown.to_html links code spans', () => {
+	it('links a bare url inside backticks, keeping code styling and safe attributes', () => {
+		const html = markdown.to_html(`\`${LINK_URL}\``)
+
+		expect(html).toContain(`<code><a href="${LINK_URL}"`)
+		expect(html).toContain(`>${LINK_URL}</a></code>`)
+		expect(html).toContain(TARGET_BLANK)
+		expect(html).toContain(REL_NOOPENER)
+	})
+
+	it('links a markdown link inside backticks', () => {
+		const html = markdown.to_html(`\`[docs](${LINK_URL})\``)
+
+		expect(html).toContain(`href="${LINK_URL}"`)
+		expect(html).toContain('>docs</a></code>')
+	})
+
+	it('leaves a non-url code span as plain escaped code', () => {
+		const html = markdown.to_html('use `queue` and `<b>&`')
+
+		expect(html).toContain(CODE_QUEUE_HTML)
+		expect(html).toContain('<code>&lt;b&gt;&amp;</code>')
+		expect(html).not.toContain('<a')
 	})
 })
 

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -87,6 +87,15 @@ describe('markdown.to_html links code spans', () => {
 		expect(html).toContain('<code>&lt;b&gt;&amp;</code>')
 		expect(html).not.toContain('<a')
 	})
+
+	it('keeps the href of a backtick-delimited url with a non-ascii path', () => {
+		const non_ascii_url = 'https://ja.wikipedia.org/wiki/日本語'
+		const html = markdown.to_html(`\`${non_ascii_url}\``)
+
+		// The url is bounded by the backticks, so the leaked-text guard must not strip its href.
+		expect(html).toContain(`<code><a href="${non_ascii_url}"`)
+		expect(html).toContain(TARGET_BLANK)
+	})
 })
 
 describe('markdown.to_html repairs leaked links', () => {

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -97,17 +97,28 @@ function codespan_renderer(token: Tokens.Codespan): string {
 	return codespan_html(token.text)
 }
 
-// LLM answers are untrusted input rendered via {@html}; every link must open safely in a new tab. An
-// inline [label](target) link whose target absorbed a sentence (the tokenizer above only covers bare
-// URLs) has an unusable href, so drop it — the label stays as text and no link points at garbage.
+// A link inside a code span was explicitly delimited by backticks, so its href is the whole URL by
+// construction — no sentence could have been swallowed. The leaked-text heuristic below must not fire
+// here, or a legitimate non-ASCII URL (e.g. a Japanese Wikipedia path) would lose its href.
+function is_in_code_span(node: Element): boolean {
+	return node.parentElement?.tagName === 'CODE'
+}
+
+// An inline [label](target) link whose target absorbed a Japanese sentence (the tokenizer above only
+// covers bare URLs) has an unusable href, so drop it — the label stays as text, pointing at no garbage.
+function strip_leaked_href(node: Element): void {
+	const href = node.getAttribute('href')
+	if (href && has_leaked_text(href)) node.removeAttribute('href')
+}
+
+// LLM answers are untrusted input rendered via {@html}; every link must open safely in a new tab.
 function harden_link(node: Element): void {
 	if (node.tagName !== 'A') return
 
 	node.setAttribute('target', '_blank')
 	node.setAttribute('rel', 'noopener noreferrer')
 
-	const href = node.getAttribute('href')
-	if (href && has_leaked_text(href)) node.removeAttribute('href')
+	if (!is_in_code_span(node)) strip_leaked_href(node)
 }
 
 // DOMPurify only works where a DOM exists (browser + jsdom tests), not during Workers SSR — and

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,5 +1,6 @@
 import DOMPurify from 'dompurify'
 import { marked, type TokenizerAndRendererExtension, type Tokens } from 'marked'
+import { markup } from './escape'
 
 // A URL written in Markdown is ASCII, so the first non-ASCII character marks where the following
 // Japanese text — a sentence, or punctuation that ends one — begins.
@@ -52,6 +53,50 @@ const bounded_url_extension: TokenizerAndRendererExtension = {
 	tokenizer: bounded_url_tokenizer,
 }
 
+// A code span whose whole content is a bare URL, or a [label](url) markdown link. The model often cites
+// documents inside backticks, where the URL is inert; linkify those so the citation stays clickable.
+const CODE_URL = /^(https?:\/\/[^\s<]+)$/u
+const CODE_MD_LINK = /^\[([^\]]+)\]\((https?:\/\/[^\s<)]+)\)$/u
+
+// marked 18 hands the codespan renderer the raw code text, so escape it with the shared markup helper —
+// which encodes every &, < > " ' exactly as marked's default codespan does — before it reaches {@html}.
+function linked_code(href: string, label: string): string {
+	return `<code><a href="${markup.escape(href)}">${markup.escape(label)}</a></code>`
+}
+
+function url_code_link(text: string): string | undefined {
+	const match = CODE_URL.exec(text)
+	if (!match) return undefined
+
+	return match[1]
+}
+
+function md_code_link(text: string): [string, string] | undefined {
+	const match = CODE_MD_LINK.exec(text)
+	if (!match) return undefined
+
+	const [, label, href] = match
+	if (label === undefined || href === undefined) return undefined
+
+	return [href, label]
+}
+
+// Keep the code styling but make the URL/link clickable; every non-link code span renders exactly as
+// marked's default. harden_link (below) later adds target/rel and drops any leaked-text href.
+function codespan_html(text: string): string {
+	const url = url_code_link(text)
+	if (url) return linked_code(url, url)
+
+	const md_link = md_code_link(text)
+	if (md_link) return linked_code(md_link[0], md_link[1])
+
+	return `<code>${markup.escape(text)}</code>`
+}
+
+function codespan_renderer(token: Tokens.Codespan): string {
+	return codespan_html(token.text)
+}
+
 // LLM answers are untrusted input rendered via {@html}; every link must open safely in a new tab. An
 // inline [label](target) link whose target absorbed a sentence (the tokenizer above only covers bare
 // URLs) has an unusable href, so drop it — the label stays as text and no link points at garbage.
@@ -69,7 +114,7 @@ function harden_link(node: Element): void {
 // to_html is only ever called client-side, so registering the hook behind a window guard is safe.
 if ('window' in globalThis) {
 	DOMPurify.addHook('afterSanitizeAttributes', harden_link)
-	marked.use({ extensions: [bounded_url_extension] })
+	marked.use({ extensions: [bounded_url_extension], renderer: { codespan: codespan_renderer } })
 }
 
 // Render Markdown from the AI chat model to HTML. The bounded_url extension keeps marked from swallowing

--- a/src/routes/chat/page.e2e.ts
+++ b/src/routes/chat/page.e2e.ts
@@ -12,7 +12,8 @@ const CHAT_MESSAGE_ASSISTANT = 'chat-message-assistant'
 const STORAGE_KEY = 'chat_log'
 const PERSISTED_QUESTION = 'What did I ask before?'
 const PERSISTED_ANSWER = 'This is the remembered answer.'
-const MARKDOWN_ANSWER = 'use `queue` and **kit**, see [docs](https://example.com)'
+const CODE_LINK_URL = 'https://example.com/kit'
+const MARKDOWN_ANSWER = `use \`queue\` and **kit**, see [docs](https://example.com) and \`${CODE_LINK_URL}\``
 const STREAMED_MARKDOWN = 'use `queue` and **kit**'
 // A tail chunk held back until the test releases it, so a still-streaming frame is observable first.
 // A real word absent from the first chunk, so it is unambiguous whether the tail has arrived yet.
@@ -254,6 +255,10 @@ test('renders assistant markdown as formatted html, not raw syntax', async ({ pa
 	await expect(messages.getByRole('link', { name: 'docs' })).toHaveAttribute(
 		'href',
 		/example\.com/u,
+	)
+	await expect(messages.locator('code a', { hasText: CODE_LINK_URL })).toHaveAttribute(
+		'href',
+		CODE_LINK_URL,
 	)
 
 	expect(await messages.innerText()).not.toContain('`')


### PR DESCRIPTION
closes #705