### PR TITLE
Render chat citation link text as <path> — <repo> instead of the flattened github__ index key #788

### DIFF
--- a/docs/ai-search-generation-prompt.md
+++ b/docs/ai-search-generation-prompt.md
@@ -47,9 +47,19 @@ existing behaviors: answering in the user's language
 ([#675](https://github.com/joshuafolkken/joshuafolkken-com/issues/675)) and handling off-topic
 questions in-band ([#665](https://github.com/joshuafolkken/joshuafolkken-com/issues/665)).
 
-> **Note:** LLM compliance for exact URLs is not 100% reliable. A deterministic, code-side
-> safety net (rewriting citations from the retrieved documents) is tracked as a separate
-> follow-up and should be executed only after this prompt is confirmed working live.
+> **Note:** LLM compliance for exact URLs is not 100% reliable, so `src/lib/utils/markdown.ts` →
+> `rewrite_citation` is the deterministic, code-side safety net. It covers both ways the flattened
+> key leaks past the prompt:
+>
+> 1. The key is the **href** (a relative link) → rewrite the href into a real GitHub blob URL on the
+>    default branch, and the label into `<path> — <repo>`.
+> 2. The key is only the **label** of a link whose href is the accurate `Source:` URL
+>    ([#788](https://github.com/joshuafolkken/joshuafolkken-com/issues/788)) → rewrite the label
+>    alone. The href is never derived from a label, because the flattened key does not encode the
+>    branch and a best-effort `main` URL would clobber a correct non-`main` one.
+>
+> The clean label is built by `github_document_key.to_display_text`, which emits the same
+> `<path> — <repo>` shape this prompt mandates, so a model-written and a rewritten citation read alike.
 
 ## Link formatting ([#747](https://github.com/joshuafolkken/joshuafolkken-com/issues/747))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "joshuafolkken-com",
-	"version": "0.306.0",
+	"version": "0.307.0",
 	"type": "module",
 	"private": true,
 	"scripts": {

--- a/src/lib/utils/github-document-key.test.ts
+++ b/src/lib/utils/github-document-key.test.ts
@@ -5,6 +5,7 @@ const REPO = 'kit'
 const DOC_PATH = 'docs/package.md'
 const DOC_KEY = 'github__kit__docs__package.md'
 const README_KEY = 'github__kit__README.md'
+const DOC_DISPLAY = 'docs/package.md — kit'
 
 describe('github_document_key.is_github_key', () => {
 	it('is true for a key carrying the github prefix', () => {
@@ -69,10 +70,43 @@ describe('github_document_key.to_github_url', () => {
 	})
 })
 
+describe('github_document_key.parse_label_key', () => {
+	it('parses a key the model wrote as the whole citation label', () => {
+		expect(github_document_key.parse_label_key(README_KEY)).toStrictEqual({
+			repo: REPO,
+			path: 'README.md',
+		})
+	})
+
+	it('stops at the repo suffix the model appends after the key', () => {
+		expect(github_document_key.parse_label_key(`${DOC_KEY} — ${REPO}`)).toStrictEqual({
+			repo: REPO,
+			path: DOC_PATH,
+		})
+	})
+
+	it('leaves prose that merely mentions a key-shaped token alone', () => {
+		// A rewrite replaces the whole label, so matching mid-sentence would discard the sentence.
+		expect(github_document_key.parse_label_key(`See ${DOC_KEY} for details`)).toBeUndefined()
+	})
+
+	it('returns undefined for text carrying no key', () => {
+		expect(github_document_key.parse_label_key(DOC_DISPLAY)).toBeUndefined()
+	})
+
+	it('returns undefined for a prefix that never completes into a key', () => {
+		expect(github_document_key.parse_label_key('github__kit')).toBeUndefined()
+	})
+})
+
 describe('github_document_key.to_display_text', () => {
-	it('joins repo and path without the flattened separators', () => {
-		expect(github_document_key.to_display_text({ repo: REPO, path: DOC_PATH })).toBe(
-			'kit/docs/package.md',
-		)
+	it('renders the prompt-mandated path and repo without the flattened separators', () => {
+		expect(github_document_key.to_display_text({ repo: REPO, path: DOC_PATH })).toBe(DOC_DISPLAY)
+	})
+
+	it('round-trips a parsed key into a clean label', () => {
+		const parsed = github_document_key.parse_key(README_KEY)
+
+		expect(parsed && github_document_key.to_display_text(parsed)).toBe('README.md — kit')
 	})
 })

--- a/src/lib/utils/github-document-key.ts
+++ b/src/lib/utils/github-document-key.ts
@@ -5,6 +5,11 @@
 
 const KEY_PREFIX = 'github__'
 const PATH_SEPARATOR = '__'
+// A citation label the model built out of the flattened key. The match runs to the first character a key
+// can never contain, so the ' — <repo>' suffix the model appends stays out of it, and it is anchored to
+// the start of the label: a rewrite replaces the label wholesale, so prose that merely mentions a
+// key-shaped token ('See github__kit__docs for the format') must not qualify.
+const LEADING_KEY = new RegExp(String.raw`^${KEY_PREFIX}[\w.-]+`, 'u')
 const GITHUB_HOST = 'https://github.com'
 const DEFAULT_OWNER = 'joshuafolkken'
 // The flattened key does not encode the source branch; ingestion labels each document with its repo's
@@ -44,15 +49,34 @@ function parse_key(key: string): ParsedDocumentKey | undefined {
 	return { repo, path: segments.join('/') }
 }
 
+// Finds a key the model wrote into a visible label rather than into an href — the whole label is the key
+// ('github__<repo>__README.md'), optionally with the model's own ' — <repo>' suffix after it. Returns
+// undefined for anything else, so a citation the model labelled correctly is left alone.
+function parse_label_key(text: string): ParsedDocumentKey | undefined {
+	const match = LEADING_KEY.exec(text.trim())
+	if (!match) return undefined
+
+	return parse_key(match[0])
+}
+
 function to_github_url(parsed: ParsedDocumentKey): string {
 	return `${GITHUB_HOST}/${DEFAULT_OWNER}/${parsed.repo}/blob/${DEFAULT_BRANCH}/${parsed.path}`
 }
 
+// '<path> — <repo>' is the citation label the generation prompt mandates (docs/ai-search-generation-prompt.md);
+// keeping the renderer's fallback on the same shape means a model-written and a rewritten citation read alike.
 function to_display_text(parsed: ParsedDocumentKey): string {
-	return `${parsed.repo}/${parsed.path}`
+	return `${parsed.path} — ${parsed.repo}`
 }
 
-const github_document_key = { is_github_key, build_key, parse_key, to_github_url, to_display_text }
+const github_document_key = {
+	is_github_key,
+	build_key,
+	parse_key,
+	parse_label_key,
+	to_github_url,
+	to_display_text,
+}
 
 export type { ParsedDocumentKey }
 export { github_document_key }

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -7,6 +7,10 @@ const CODE_QUEUE_HTML = '<code>queue</code>'
 const STRONG_KIT_HTML = '<strong>kit</strong>'
 const TARGET_BLANK = 'target="_blank"'
 const REL_NOOPENER = 'rel="noopener noreferrer"'
+const DOC_KEY = 'github__kit__docs__package.md'
+const DOC_DISPLAY = 'docs/package.md — kit'
+// A Source URL on a non-default branch: proof that a correct href is never re-derived from a key.
+const SOURCE_URL = 'https://github.com/joshuafolkken/kit/blob/master/docs/package.md'
 
 describe('markdown.to_html', () => {
 	it('renders inline code without literal backticks', () => {
@@ -134,7 +138,7 @@ describe('markdown.to_html repairs leaked links', () => {
 })
 
 describe('markdown.to_html rewrites flattened github__ citation links', () => {
-	const CITATION = '[github__kit__docs__package.md](github__kit__docs__package.md)'
+	const CITATION = `[${DOC_KEY}](${DOC_KEY})`
 	const BLOB_URL = 'https://github.com/joshuafolkken/kit/blob/main/docs/package.md'
 
 	it('rewrites a flattened key link to a real GitHub blob URL', () => {
@@ -146,14 +150,14 @@ describe('markdown.to_html rewrites flattened github__ citation links', () => {
 	it('shows clean display text without the doubled-underscore key', () => {
 		const html = markdown.to_html(CITATION)
 
-		expect(html).toContain('kit/docs/package.md')
+		expect(html).toContain(DOC_DISPLAY)
 		expect(html).not.toContain('github__kit')
 	})
 
 	it('no longer leaves a relative href that resolves to the site origin', () => {
 		const html = markdown.to_html(CITATION)
 
-		expect(html).not.toContain('href="github__kit__docs__package.md"')
+		expect(html).not.toContain(`href="${DOC_KEY}"`)
 	})
 
 	it('leaves a normal absolute link unchanged', () => {
@@ -162,20 +166,51 @@ describe('markdown.to_html rewrites flattened github__ citation links', () => {
 		expect(html).toContain(`href="${LINK_URL}"`)
 	})
 
-	it('keeps a valid absolute href even when the link label looks like a key', () => {
-		// The accurate #697 path: the model links the real Source URL (correct branch) but labels it with
-		// the key. Detecting on text would clobber a correct href with a wrong best-effort main URL.
-		const source_url = 'https://github.com/joshuafolkken/kit/blob/master/docs/package.md'
-		const html = markdown.to_html(`[github__kit__docs__package.md](${source_url})`)
-
-		expect(html).toContain(`href="${source_url}"`)
-		expect(html).not.toContain('blob/main')
-	})
-
 	it('hardens the rewritten link with target and rel', () => {
 		const html = markdown.to_html(CITATION)
 
 		expect(html).toContain(TARGET_BLANK)
 		expect(html).toContain(REL_NOOPENER)
+	})
+})
+
+describe('markdown.to_html cleans a flattened key out of a citation label', () => {
+	// The accurate #697 path: the model links the real Source URL (correct branch) but labels it with the
+	// key. Only the label is rewritten — re-deriving the href would clobber a correct branch with main.
+	it('keeps a valid absolute href even when the link label looks like a key', () => {
+		const html = markdown.to_html(`[${DOC_KEY}](${SOURCE_URL})`)
+
+		expect(html).toContain(`href="${SOURCE_URL}"`)
+		expect(html).not.toContain('blob/main')
+	})
+
+	it('replaces the key label with the path and repo display text (#788)', () => {
+		const html = markdown.to_html(`[${DOC_KEY}](${SOURCE_URL})`)
+
+		expect(html).toContain(DOC_DISPLAY)
+		expect(html).not.toContain('github__kit')
+	})
+
+	it('drops the repo suffix the model appends after the key (#788)', () => {
+		const readme_url = 'https://github.com/joshuafolkken/joshuafolkken/blob/main/README.md'
+		const html = markdown.to_html(
+			`[github__joshuafolkken__README.md — joshuafolkken](${readme_url})`,
+		)
+
+		expect(html).toContain('>README.md — joshuafolkken<')
+		expect(html).not.toContain('github__joshuafolkken')
+	})
+
+	it('leaves a correctly labelled citation untouched', () => {
+		const html = markdown.to_html(`[${DOC_DISPLAY}](${SOURCE_URL})`)
+
+		expect(html).toContain(DOC_DISPLAY)
+		expect(html).toContain(`href="${SOURCE_URL}"`)
+	})
+
+	it('leaves a label that only mentions a key in prose intact', () => {
+		const html = markdown.to_html(`[the ${DOC_KEY} format](${SOURCE_URL})`)
+
+		expect(html).toContain(`the ${DOC_KEY} format`)
 	})
 })

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,7 +1,7 @@
 import DOMPurify from 'dompurify'
 import { marked, type Token, type TokenizerAndRendererExtension, type Tokens } from 'marked'
 import { markup } from './escape'
-import { github_document_key } from './github-document-key'
+import { github_document_key, type ParsedDocumentKey } from './github-document-key'
 
 // A URL written in Markdown is ASCII, so the first non-ASCII character marks where the following
 // Japanese text — a sentence, or punctuation that ends one — begins.
@@ -128,23 +128,32 @@ function is_link_token(token: Token): token is Tokens.Link {
 	return token.type === 'link'
 }
 
+// The label carries the whole citation, so replacing it wholesale (rather than substituting the key in
+// place) also drops the ' — <repo>' suffix the model appends after the key, which to_display_text re-adds.
+function set_display_text(token: Tokens.Link, parsed: ParsedDocumentKey): void {
+	const text = github_document_key.to_display_text(parsed)
+
+	token.text = text
+	token.tokens = [{ type: 'text', raw: text, text }]
+}
+
 // Deterministic safety net for the RAG model's broken citations: when the model wraps a document's
 // flattened index key (github__<repo>__<path>) in a relative link, it would otherwise render as a broken
 // same-origin URL with doubled underscores. Rewrite it into a real GitHub URL with clean display text
-// before marked renders it. Detection is on the href only — a link that already carries a valid absolute
-// URL (even one whose label looks like a key) is the accurate citation path and must be left untouched,
-// or a repo on a non-main branch would have its correct href replaced by a wrong best-effort main URL.
+// before marked renders it. The key can also leak into the label alone (#788), on a link whose href is the
+// accurate absolute Source URL; that case rewrites the label only — replacing the href would swap a
+// correct non-main-branch URL for a wrong best-effort main one.
 function rewrite_citation(token: Token): void {
 	if (!is_link_token(token)) return
 
-	const parsed = github_document_key.parse_key(token.href)
+	const href_parsed = github_document_key.parse_key(token.href)
+
+	if (href_parsed) token.href = github_document_key.to_github_url(href_parsed)
+
+	const parsed = href_parsed ?? github_document_key.parse_label_key(token.text)
 	if (!parsed) return
 
-	const text = github_document_key.to_display_text(parsed)
-
-	token.href = github_document_key.to_github_url(parsed)
-	token.text = text
-	token.tokens = [{ type: 'text', raw: text, text }]
+	set_display_text(token, parsed)
 }
 
 // DOMPurify only works where a DOM exists (browser + jsdom tests), not during Workers SSR — and

--- a/src/routes/chat/citation.e2e.ts
+++ b/src/routes/chat/citation.e2e.ts
@@ -7,7 +7,12 @@ const STORAGE_KEY = 'chat_log'
 const CITATION_KEY = 'github__kit__docs__package.md'
 const CITATION_ANSWER = `See [${CITATION_KEY}](${CITATION_KEY}) for the details.`
 const CITATION_BLOB_URL = 'https://github.com/joshuafolkken/kit/blob/main/docs/package.md'
-const CITATION_DISPLAY = 'kit/docs/package.md'
+const CITATION_DISPLAY = 'docs/package.md — kit'
+// The other half of the defect: an accurate absolute Source URL labelled with the flattened key.
+const LABELLED_KEY = 'github__joshuafolkken__README.md'
+const LABELLED_URL = 'https://github.com/joshuafolkken/joshuafolkken/blob/main/README.md'
+const LABELLED_ANSWER = `Reference: [${LABELLED_KEY} — joshuafolkken](${LABELLED_URL})`
+const LABELLED_DISPLAY = 'README.md — joshuafolkken'
 
 // Seed a stored assistant answer so the reply renders through the real {@html markdown.to_html(...)} path
 // on reload — no chat backend required to exercise the rendered output.
@@ -39,4 +44,19 @@ test('rewrites a flattened github__ citation into a real GitHub link', async ({ 
 
 	// The broken relative key and its doubled-underscore display must not survive into the output.
 	expect(await messages.innerText()).not.toContain(CITATION_KEY)
+})
+
+test('cleans a flattened key out of a citation label while keeping its source URL', async ({
+	page,
+}) => {
+	await page.goto('/chat')
+	await seed_answer(page, LABELLED_ANSWER)
+	await page.reload()
+
+	const messages = page.getByTestId(CHAT_MESSAGES)
+	const link = messages.getByRole('link', { name: LABELLED_DISPLAY })
+
+	// The accurate Source URL the model cited is preserved; only the leaked key is cleaned out.
+	await expect(link).toHaveAttribute('href', LABELLED_URL)
+	expect(await messages.innerText()).not.toContain(LABELLED_KEY)
 })


### PR DESCRIPTION
closes #788