### PR TITLE
Normalize a GitHub citation label that repeats the repo name before the path #794

### DIFF
--- a/docs/ai-search-generation-prompt.md
+++ b/docs/ai-search-generation-prompt.md
@@ -48,18 +48,29 @@ existing behaviors: answering in the user's language
 questions in-band ([#665](https://github.com/joshuafolkken/joshuafolkken-com/issues/665)).
 
 > **Note:** LLM compliance for exact URLs is not 100% reliable, so `src/lib/utils/markdown.ts` →
-> `rewrite_citation` is the deterministic, code-side safety net. It covers both ways the flattened
-> key leaks past the prompt:
+> `rewrite_citation` is the deterministic, code-side safety net. It covers every way a document's
+> internal identity leaks into what the reader sees:
 >
-> 1. The key is the **href** (a relative link) → rewrite the href into a real GitHub blob URL on the
->    default branch, and the label into `<path> — <repo>`.
+> 1. The flattened key is the **href** (a relative link) → rewrite the href into a real GitHub blob
+>    URL on the default branch, and the label into `<path> — <repo>`.
 > 2. The key is only the **label** of a link whose href is the accurate `Source:` URL
 >    ([#788](https://github.com/joshuafolkken/joshuafolkken-com/issues/788)) → rewrite the label
->    alone. The href is never derived from a label, because the flattened key does not encode the
->    branch and a best-effort `main` URL would clobber a correct non-`main` one.
+>    alone.
+> 3. The **H1 above** (`# <repo> — <path>`) is the label, with the model's own ` — <repo>` appended,
+>    giving `<repo> — <path> — <repo>`
+>    ([#794](https://github.com/joshuafolkken/joshuafolkken-com/issues/794)) → rebuild the label from
+>    the href. Detection requires the label to open with the href's own repo, so a deliberate
+>    descriptive label is never rewritten.
+>
+> Only case 1 touches the href. A label never determines a URL: the flattened key encodes no branch,
+> so a best-effort `main` URL would clobber a correct non-`main` one.
 >
 > The clean label is built by `github_document_key.to_display_text`, which emits the same
 > `<path> — <repo>` shape this prompt mandates, so a model-written and a rewritten citation read alike.
+>
+> Case 3 exists because the H1 and the citation convention share the `—` separator, which invites
+> the model to treat the H1 as the "page title" the site-page rule asks for. The prompt rule below
+> ("never use the document's own H1 heading") is the primary guard; the renderer is the net.
 
 ## Link formatting ([#747](https://github.com/joshuafolkken/joshuafolkken-com/issues/747))
 
@@ -143,6 +154,11 @@ Citations:
 - Never output the flattened index key or filename (e.g. `github__kit__docs__package.md`), never
   emit doubled underscores (`__`) as citation text, never show a bare URL as the link text, and
   never produce a relative link.
+- For a GitHub document, never use the document's own H1 heading (`# <repo> — <path>`) as the link
+  text, and never put the repository name before the path. The label is exactly `<path> — <repo>`,
+  with the repository named once — write `README.md — kit`, never `kit — README.md` or
+  `kit — README.md — kit`. The "use the page's own title" rule applies only to joshuafolkken.com
+  pages.
 - If a retrieved document has no source URL, mention it by its title without fabricating a URL.
 
 Citation placement:
@@ -165,6 +181,8 @@ After applying the prompt on the dashboard, confirm on the live `/chat` (and the
    shows the page's own title (e.g. `About - Joshua Folkken`), falling back to
    `<path> — joshuafolkken.com` (e.g. `about — joshuafolkken.com`) only when the retrieved
    content carries no title — never a bare URL, a `__`-flattened filename, or a relative link.
+   The repository is named exactly once: never `joshuafolkken — README.md — joshuafolkken` or
+   `kit — README.md` (the #794 guard).
 2. A Japanese question still gets a Japanese answer with citations (the #675 regression guard).
 3. An off-topic question is politely declined in the user's language (the #665 behavior).
 4. Every citation appears together at the very end of the answer — none inline in a sentence and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "joshuafolkken-com",
-	"version": "0.307.0",
+	"version": "0.308.0",
 	"type": "module",
 	"private": true,
 	"scripts": {
@@ -78,7 +78,7 @@
 		"eslint-plugin-sonarjs": "^4.2.0",
 		"eslint-plugin-svelte": "^3.22.0",
 		"eslint-plugin-unicorn": "^72.0.0",
-		"globals": "^17.7.0",
+		"globals": "^17.8.0",
 		"jsdom": "^29.1.1",
 		"kill-port": "^2.0.1",
 		"lefthook": "2.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,8 +330,8 @@ importers:
         specifier: ^72.0.0
         version: 72.0.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       globals:
-        specifier: ^17.7.0
-        version: 17.7.0
+        specifier: ^17.8.0
+        version: 17.8.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -2402,8 +2402,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.11.3:
-    resolution: {integrity: sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==}
+  baseline-browser-mapping@2.11.4:
+    resolution: {integrity: sha512-s4+sLr9mZ/CyqeRritFeYV/Zx73OAtmaHn6kkBS1XRoJn1hrg3xIDUcpicAEX68tkcIN0iBCgti31C8zxtkhsQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3089,8 +3089,8 @@ packages:
     resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
-  globals@17.7.0:
-    resolution: {integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==}
+  globals@17.8.0:
+    resolution: {integrity: sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==}
     engines: {node: '>=18'}
 
   google-auth-library@10.9.1:
@@ -4067,8 +4067,8 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  smol-toml@1.7.0:
-    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
+  smol-toml@1.7.1:
+    resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -4612,16 +4612,16 @@ packages:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  yoctocolors@2.1.2:
-    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
     engines: {node: '>=18'}
 
   youch-core@0.3.3:
@@ -5440,7 +5440,7 @@ snapshots:
       eslint-plugin-sonarjs: 4.2.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       eslint-plugin-unicorn: 72.0.0(eslint@10.8.0(jiti@2.7.0)(supports-color@10.2.2))
       execa: 10.0.0
-      globals: 17.7.0
+      globals: 17.8.0
       js-yaml: 5.2.2
       ora: 9.4.1
       semver: 7.8.5
@@ -6315,7 +6315,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.11.3: {}
+  baseline-browser-mapping@2.11.4: {}
 
   better-sqlite3@13.0.1:
     dependencies:
@@ -6341,7 +6341,7 @@ snapshots:
 
   browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.11.3
+      baseline-browser-mapping: 2.11.4
       caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.396
       node-releases: 2.0.51
@@ -6442,7 +6442,7 @@ snapshots:
     dependencies:
       '@cspell/cspell-types': 10.0.1
       comment-json: 5.0.0
-      smol-toml: 1.7.0
+      smol-toml: 1.7.1
       yaml: 2.9.0
 
   cspell-dictionary@10.0.1:
@@ -6713,7 +6713,7 @@ snapshots:
       bytes: 3.1.2
       eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       functional-red-black-tree: 1.0.1
-      globals: 17.7.0
+      globals: 17.8.0
       jsx-ast-utils-x: 0.1.0
       lodash.merge: 4.6.2
       minimatch: 10.2.5
@@ -6753,7 +6753,7 @@ snapshots:
       entities: 4.5.0
       eslint: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
       find-up-simple: 1.0.1
-      globals: 17.7.0
+      globals: 17.8.0
       indent-string: 5.0.0
       is-builtin-module: 5.0.0
       is-identifier: 1.1.0
@@ -6874,7 +6874,7 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       which-command: 0.1.0
-      yoctocolors: 2.1.2
+      yoctocolors: 2.2.0
 
   expect-type@1.4.0: {}
 
@@ -6980,7 +6980,7 @@ snapshots:
 
   globals@16.5.0: {}
 
-  globals@17.7.0: {}
+  globals@17.8.0: {}
 
   google-auth-library@10.9.1(supports-color@10.2.2):
     dependencies:
@@ -7360,7 +7360,7 @@ snapshots:
   log-symbols@7.0.1:
     dependencies:
       is-unicode-supported: 2.1.0
-      yoctocolors: 2.1.2
+      yoctocolors: 2.2.0
 
   long@5.3.2: {}
 
@@ -7710,7 +7710,7 @@ snapshots:
       open: 11.0.0
       picomatch: 4.0.5
       source-map: 0.7.6
-      yargs: 18.0.0
+      yargs: 18.1.0
     optionalDependencies:
       rolldown: 1.1.5
       rollup: 4.62.2
@@ -7881,7 +7881,7 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  smol-toml@1.7.0: {}
+  smol-toml@1.7.1: {}
 
   source-map-js@1.2.1: {}
 
@@ -8379,18 +8379,18 @@ snapshots:
 
   yargs-parser@22.0.0: {}
 
-  yargs@18.0.0:
+  yargs@18.1.0:
     dependencies:
       cliui: 9.0.1
       escalade: 3.2.0
       get-caller-file: 2.0.5
-      string-width: 7.2.0
+      string-width: 8.2.2
       y18n: 5.0.8
       yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}
 
-  yoctocolors@2.1.2: {}
+  yoctocolors@2.2.0: {}
 
   youch-core@0.3.3:
     dependencies:

--- a/src/lib/utils/github-document-key.test.ts
+++ b/src/lib/utils/github-document-key.test.ts
@@ -6,6 +6,7 @@ const DOC_PATH = 'docs/package.md'
 const DOC_KEY = 'github__kit__docs__package.md'
 const README_KEY = 'github__kit__README.md'
 const DOC_DISPLAY = 'docs/package.md — kit'
+const DOC_URL = 'https://github.com/joshuafolkken/kit/blob/main/docs/package.md'
 
 describe('github_document_key.is_github_key', () => {
 	it('is true for a key carrying the github prefix', () => {
@@ -64,9 +65,7 @@ describe('github_document_key.parse_key', () => {
 
 describe('github_document_key.to_github_url', () => {
 	it('builds a blob URL on the default branch', () => {
-		expect(github_document_key.to_github_url({ repo: REPO, path: DOC_PATH })).toBe(
-			'https://github.com/joshuafolkken/kit/blob/main/docs/package.md',
-		)
+		expect(github_document_key.to_github_url({ repo: REPO, path: DOC_PATH })).toBe(DOC_URL)
 	})
 })
 
@@ -96,6 +95,72 @@ describe('github_document_key.parse_label_key', () => {
 
 	it('returns undefined for a prefix that never completes into a key', () => {
 		expect(github_document_key.parse_label_key('github__kit')).toBeUndefined()
+	})
+})
+
+describe('github_document_key.parse_repo_prefixed_label', () => {
+	it('parses a label that leads with the repo and repeats it after the path', () => {
+		const label = `${REPO} — ${DOC_PATH} — ${REPO}`
+
+		expect(github_document_key.parse_repo_prefixed_label(DOC_URL, label)).toStrictEqual({
+			repo: REPO,
+			path: DOC_PATH,
+		})
+	})
+
+	it('parses the suffix-less variant, which is the bare document H1', () => {
+		expect(
+			github_document_key.parse_repo_prefixed_label(DOC_URL, `${REPO} — ${DOC_PATH}`),
+		).toStrictEqual({ repo: REPO, path: DOC_PATH })
+	})
+
+	it('reads the repo and path off a URL on a non-default branch', () => {
+		const url = 'https://github.com/joshuafolkken/.github/blob/master/README.md'
+
+		expect(github_document_key.parse_repo_prefixed_label(url, '.github — README.md')).toStrictEqual(
+			{
+				repo: '.github',
+				path: 'README.md',
+			},
+		)
+	})
+})
+
+describe('github_document_key.parse_repo_prefixed_label leaves other labels alone', () => {
+	it('returns undefined for a correctly labelled citation', () => {
+		expect(github_document_key.parse_repo_prefixed_label(DOC_URL, DOC_DISPLAY)).toBeUndefined()
+	})
+
+	it('returns undefined for a descriptive label that does not lead with the repo', () => {
+		expect(
+			github_document_key.parse_repo_prefixed_label(DOC_URL, 'the package doc — kit'),
+		).toBeUndefined()
+	})
+
+	it('returns undefined when the href is not a GitHub blob URL', () => {
+		expect(
+			github_document_key.parse_repo_prefixed_label(
+				'https://joshuafolkken.com/about',
+				'kit — x.md',
+			),
+		).toBeUndefined()
+	})
+
+	it('returns undefined for a repo root URL carrying no document path', () => {
+		expect(
+			github_document_key.parse_repo_prefixed_label(
+				'https://github.com/joshuafolkken/kit',
+				'kit — ',
+			),
+		).toBeUndefined()
+	})
+
+	it('returns undefined when the path carries markup characters', () => {
+		// The href is untrusted model output and the path becomes visible label text, so a path that could
+		// smuggle HTML must not parse at all.
+		const url = 'https://github.com/joshuafolkken/kit/blob/main/"><img src=x>'
+
+		expect(github_document_key.parse_repo_prefixed_label(url, 'kit — x')).toBeUndefined()
 	})
 })
 

--- a/src/lib/utils/github-document-key.ts
+++ b/src/lib/utils/github-document-key.ts
@@ -12,6 +12,18 @@ const PATH_SEPARATOR = '__'
 const LEADING_KEY = new RegExp(String.raw`^${KEY_PREFIX}[\w.-]+`, 'u')
 const GITHUB_HOST = 'https://github.com'
 const DEFAULT_OWNER = 'joshuafolkken'
+// ' — ' joins a citation label; it is also what ingestion puts between repo and path in a document's H1,
+// which is why a label can end up carrying both (see parse_repo_prefixed_label).
+const DISPLAY_SEPARATOR = ' — '
+const HOST_PATTERN = GITHUB_HOST.replaceAll('.', String.raw`\.`)
+// Inverse shape of to_github_url, but for any owner and branch — a real Source: URL names the repo's own
+// default branch, which the flattened key never encodes. The trailing group keeps nested path segments,
+// while excluding the markup characters a URL would percent-encode: this href is untrusted model output,
+// and the captured path becomes visible label text, so it must not be able to carry HTML.
+const BLOB_URL = new RegExp(
+	String.raw`^${HOST_PATTERN}/[^/]+/([^/]+)/blob/[^/]+/([^\s"'<>]+)$`,
+	'u',
+)
 // The flattened key does not encode the source branch; ingestion labels each document with its repo's
 // real default_branch (the accurate Source: URL), so main is a best-effort fallback for the renderer.
 const DEFAULT_BRANCH = 'main'
@@ -63,10 +75,32 @@ function to_github_url(parsed: ParsedDocumentKey): string {
 	return `${GITHUB_HOST}/${DEFAULT_OWNER}/${parsed.repo}/blob/${DEFAULT_BRANCH}/${parsed.path}`
 }
 
+function parse_github_url(href: string): ParsedDocumentKey | undefined {
+	const match = BLOB_URL.exec(href)
+	if (!match) return undefined
+
+	const [, repo, path] = match
+	if (repo === undefined || path === undefined) return undefined
+
+	return { repo, path }
+}
+
+// Ingestion titles each document '# <repo> — <path>' (scripts/github-documentation.ts). The model
+// sometimes cites that H1 as the label and then appends its own ' — <repo>', yielding
+// '<repo> — <path> — <repo>'. Detect only that shape — a label opening with the href's own repo — so the
+// renderer can rebuild it from the href, which is the authority here; a descriptive label that does not
+// lead with the repo is a deliberate one and must survive untouched.
+function parse_repo_prefixed_label(href: string, text: string): ParsedDocumentKey | undefined {
+	const parsed = parse_github_url(href)
+	if (!parsed) return undefined
+
+	return text.trim().startsWith(`${parsed.repo}${DISPLAY_SEPARATOR}`) ? parsed : undefined
+}
+
 // '<path> — <repo>' is the citation label the generation prompt mandates (docs/ai-search-generation-prompt.md);
 // keeping the renderer's fallback on the same shape means a model-written and a rewritten citation read alike.
 function to_display_text(parsed: ParsedDocumentKey): string {
-	return `${parsed.path} — ${parsed.repo}`
+	return `${parsed.path}${DISPLAY_SEPARATOR}${parsed.repo}`
 }
 
 const github_document_key = {
@@ -74,6 +108,7 @@ const github_document_key = {
 	build_key,
 	parse_key,
 	parse_label_key,
+	parse_repo_prefixed_label,
 	to_github_url,
 	to_display_text,
 }

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -8,9 +8,12 @@ const STRONG_KIT_HTML = '<strong>kit</strong>'
 const TARGET_BLANK = 'target="_blank"'
 const REL_NOOPENER = 'rel="noopener noreferrer"'
 const DOC_KEY = 'github__kit__docs__package.md'
-const DOC_DISPLAY = 'docs/package.md — kit'
+const DOC_PATH = 'docs/package.md'
+const DOC_DISPLAY = `${DOC_PATH} — kit`
 // A Source URL on a non-default branch: proof that a correct href is never re-derived from a key.
 const SOURCE_URL = 'https://github.com/joshuafolkken/kit/blob/master/docs/package.md'
+const README_URL = 'https://github.com/joshuafolkken/joshuafolkken/blob/main/README.md'
+const README_DISPLAY = 'README.md — joshuafolkken'
 
 describe('markdown.to_html', () => {
 	it('renders inline code without literal backticks', () => {
@@ -192,12 +195,11 @@ describe('markdown.to_html cleans a flattened key out of a citation label', () =
 	})
 
 	it('drops the repo suffix the model appends after the key (#788)', () => {
-		const readme_url = 'https://github.com/joshuafolkken/joshuafolkken/blob/main/README.md'
 		const html = markdown.to_html(
-			`[github__joshuafolkken__README.md — joshuafolkken](${readme_url})`,
+			`[github__joshuafolkken__README.md — joshuafolkken](${README_URL})`,
 		)
 
-		expect(html).toContain('>README.md — joshuafolkken<')
+		expect(html).toContain(`>${README_DISPLAY}<`)
 		expect(html).not.toContain('github__joshuafolkken')
 	})
 
@@ -212,5 +214,46 @@ describe('markdown.to_html cleans a flattened key out of a citation label', () =
 		const html = markdown.to_html(`[the ${DOC_KEY} format](${SOURCE_URL})`)
 
 		expect(html).toContain(`the ${DOC_KEY} format`)
+	})
+})
+
+// The model cites the document's '<repo> — <path>' H1 as the label, then appends its own ' — <repo>'.
+describe('markdown.to_html normalizes a citation label that repeats the repo (#794)', () => {
+	it('collapses the repeated repo around the path', () => {
+		const html = markdown.to_html(`[joshuafolkken — README.md — joshuafolkken](${README_URL})`)
+
+		expect(html).toContain(`>${README_DISPLAY}<`)
+	})
+
+	it('normalizes a repo whose name starts with a dot', () => {
+		const url = 'https://github.com/joshuafolkken/.github/blob/main/README.md'
+		const html = markdown.to_html(`[.github — README.md — .github](${url})`)
+
+		expect(html).toContain('>README.md — .github<')
+	})
+
+	it('reorders the bare document H1 that carries no repeated suffix', () => {
+		const html = markdown.to_html(`[joshuafolkken — README.md](${README_URL})`)
+
+		expect(html).toContain(`>${README_DISPLAY}<`)
+	})
+
+	it('keeps the cited source URL rather than rebuilding it from the label', () => {
+		const html = markdown.to_html(`[kit — ${DOC_PATH} — kit](${SOURCE_URL})`)
+
+		expect(html).toContain(`href="${SOURCE_URL}"`)
+		expect(html).not.toContain('blob/main')
+	})
+
+	it('leaves a descriptive label that does not lead with the repo', () => {
+		const html = markdown.to_html(`[the package doc — kit](${SOURCE_URL})`)
+
+		expect(html).toContain('the package doc — kit')
+	})
+
+	it('leaves a repo-prefixed label on a non-GitHub link', () => {
+		const html = markdown.to_html('[kit — README.md — kit](https://joshuafolkken.com/projects)')
+
+		expect(html).toContain('kit — README.md — kit')
 	})
 })

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -137,12 +137,23 @@ function set_display_text(token: Tokens.Link, parsed: ParsedDocumentKey): void {
 	token.tokens = [{ type: 'text', raw: text, text }]
 }
 
-// Deterministic safety net for the RAG model's broken citations: when the model wraps a document's
-// flattened index key (github__<repo>__<path>) in a relative link, it would otherwise render as a broken
-// same-origin URL with doubled underscores. Rewrite it into a real GitHub URL with clean display text
-// before marked renders it. The key can also leak into the label alone (#788), on a link whose href is the
-// accurate absolute Source URL; that case rewrites the label only — replacing the href would swap a
-// correct non-main-branch URL for a wrong best-effort main one.
+// The label alone is malformed, so the href — an accurate Source URL — is the only authority left for
+// rebuilding it. Ordered after the key checks because those also carry the (possibly broken) href.
+function parse_label_only(token: Tokens.Link): ParsedDocumentKey | undefined {
+	return (
+		github_document_key.parse_label_key(token.text) ??
+		github_document_key.parse_repo_prefixed_label(token.href, token.text)
+	)
+}
+
+// Deterministic safety net for the RAG model's broken citations, covering every way a document's identity
+// leaks into what the reader sees:
+//   1. The flattened index key (github__<repo>__<path>) as the href of a relative link — it would render
+//      as a broken same-origin URL with doubled underscores, so href and label are both rewritten.
+//   2. The key as the label of a link whose href is already the accurate Source URL (#788).
+//   3. The document's '<repo> — <path>' H1 as the label, with the model's own ' — <repo>' appended (#794).
+// Only case 1 touches the href: deriving one from a label would swap a correct non-main-branch URL for a
+// wrong best-effort main one, since the key encodes no branch.
 function rewrite_citation(token: Token): void {
 	if (!is_link_token(token)) return
 
@@ -150,7 +161,7 @@ function rewrite_citation(token: Token): void {
 
 	if (href_parsed) token.href = github_document_key.to_github_url(href_parsed)
 
-	const parsed = href_parsed ?? github_document_key.parse_label_key(token.text)
+	const parsed = href_parsed ?? parse_label_only(token)
 	if (!parsed) return
 
 	set_display_text(token, parsed)

--- a/src/routes/chat/citation.e2e.ts
+++ b/src/routes/chat/citation.e2e.ts
@@ -13,6 +13,9 @@ const LABELLED_KEY = 'github__joshuafolkken__README.md'
 const LABELLED_URL = 'https://github.com/joshuafolkken/joshuafolkken/blob/main/README.md'
 const LABELLED_ANSWER = `Reference: [${LABELLED_KEY} — joshuafolkken](${LABELLED_URL})`
 const LABELLED_DISPLAY = 'README.md — joshuafolkken'
+// A third shape: the model cites the document's '<repo> — <path>' H1 and appends its own ' — <repo>'.
+const REPEATED_LABEL = 'joshuafolkken — README.md — joshuafolkken'
+const REPEATED_ANSWER = `Reference: [${REPEATED_LABEL}](${LABELLED_URL})`
 
 // Seed a stored assistant answer so the reply renders through the real {@html markdown.to_html(...)} path
 // on reload — no chat backend required to exercise the rendered output.
@@ -59,4 +62,17 @@ test('cleans a flattened key out of a citation label while keeping its source UR
 	// The accurate Source URL the model cited is preserved; only the leaked key is cleaned out.
 	await expect(link).toHaveAttribute('href', LABELLED_URL)
 	expect(await messages.innerText()).not.toContain(LABELLED_KEY)
+})
+
+test('collapses a citation label that repeats the repo around the path', async ({ page }) => {
+	await page.goto('/chat')
+	await seed_answer(page, REPEATED_ANSWER)
+	await page.reload()
+
+	const messages = page.getByTestId(CHAT_MESSAGES)
+	const link = messages.getByRole('link', { name: LABELLED_DISPLAY, exact: true })
+
+	await expect(link).toHaveAttribute('href', LABELLED_URL)
+	// The duplicated repo prefix must not survive into the rendered label.
+	expect(await messages.innerText()).not.toContain(REPEATED_LABEL)
 })


### PR DESCRIPTION
closes #794