### PR TITLE
Unify the page-title separator on the em dash and single-source the title builder #795

### DIFF
--- a/docs/ai-search-generation-prompt.md
+++ b/docs/ai-search-generation-prompt.md
@@ -147,7 +147,7 @@ Citations:
   - A GitHub document → use `<path> — <repo>`, e.g.
     [docs/package.md — kit](https://github.com/joshuafolkken/kit/blob/main/docs/package.md).
   - A joshuafolkken.com page → use the page's own title from the retrieved content as the link
-    text, e.g. [About - Joshua Folkken](https://joshuafolkken.com/about). If the retrieved
+    text, e.g. [About — Joshua Folkken](https://joshuafolkken.com/about). If the retrieved
     content carries no page title, fall back to `<path> — joshuafolkken.com` (`<path>` is the URL
     path after the domain, `home` for the root `/`) — but never show the bare URL as the link
     text.
@@ -178,7 +178,7 @@ After applying the prompt on the dashboard, confirm on the live `/chat` (and the
 
 1. A GitHub-sourced citation shows clean display text `[<path> — <repo>]` (e.g.
    `docs/package.md — kit`) on a real `github.com/...` URL, and a joshuafolkken.com citation
-   shows the page's own title (e.g. `About - Joshua Folkken`), falling back to
+   shows the page's own title (e.g. `About — Joshua Folkken`), falling back to
    `<path> — joshuafolkken.com` (e.g. `about — joshuafolkken.com`) only when the retrieved
    content carries no title — never a bare URL, a `__`-flattened filename, or a relative link.
    The repository is named exactly once: never `joshuafolkken — README.md — joshuafolkken` or

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "joshuafolkken-com",
-	"version": "0.308.0",
+	"version": "0.309.0",
 	"type": "module",
 	"private": true,
 	"scripts": {

--- a/src/lib/app.test.ts
+++ b/src/lib/app.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { app, AUTHOR } from './app'
+
+describe('app.page_title', () => {
+	it('joins the page title and the author name', () => {
+		expect(app.page_title('About')).toBe('About — Joshua Folkken')
+	})
+
+	it('separates with an em dash, never a hyphen', () => {
+		// The /chat assistant cites site pages by this title beside GitHub citations that use an em dash.
+		expect(app.page_title('About')).toContain(' — ')
+		expect(app.page_title('About')).not.toContain(' - ')
+	})
+
+	it('stays unambiguous for a title that itself contains a hyphen', () => {
+		// The reason for the em dash: a hyphen separator would be indistinguishable from the one in the name.
+		const title = app.page_title('game-kit')
+
+		expect(title).toBe('game-kit — Joshua Folkken')
+		expect(title.split(' — ')).toStrictEqual(['game-kit', AUTHOR.NAME])
+	})
+
+	it('keeps an empty page title from producing a leading separator alone', () => {
+		expect(app.page_title('')).toBe(` — ${AUTHOR.NAME}`)
+	})
+})

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -72,8 +72,20 @@ function link_label(type: keyof typeof LINK_LABELS): string {
 	return LINK_LABELS[type]
 }
 
+// An em dash, not a hyphen: the names this joins contain hyphens of their own (game-kit, app-kit,
+// godot-project-template), so a hyphen separator would be indistinguishable from one inside the title it
+// separates. The /chat assistant cites a site page by this exact title, where it sits beside GitHub
+// citations that already use the em dash — one separator keeps a citation list readable (#795).
+const TITLE_SEPARATOR = ' — '
+
+// Single source for every page's <title> and OGP title, so the format can never drift per route.
+function page_title(title: string): string {
+	return `${title}${TITLE_SEPARATOR}${AUTHOR.NAME}`
+}
+
 const app = {
 	link_label,
+	page_title,
 }
 
 export {

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { APP, AUTHOR, OPENCOLLECTIVE, URLS } from '$lib/app'
+	import { APP, app, AUTHOR, OPENCOLLECTIVE, URLS } from '$lib/app'
 	import AdSenseScript from '$lib/components/AdSenseScript.svelte'
 	import EngagementButtons from '$lib/components/EngagementButtons.svelte'
 	import ExternalLink from '$lib/components/ExternalLink.svelte'
@@ -20,7 +20,7 @@
 	import { CONTACT_HREF } from '$lib/constants/page-routes'
 	import { PAGES } from '$lib/types/page'
 
-	const title = `${PAGES.ABOUT.title} - ${AUTHOR.NAME}`
+	const title = app.page_title(PAGES.ABOUT.title)
 </script>
 
 <svelte:head>

--- a/src/routes/blog/+page.svelte
+++ b/src/routes/blog/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { APP, AUTHOR } from '$lib/app'
+	import { APP, app } from '$lib/app'
 	import AdSenseScript from '$lib/components/AdSenseScript.svelte'
 	import BlogList from '$lib/components/BlogList.svelte'
 	import MetaTags from '$lib/components/MetaTags.svelte'
@@ -9,7 +9,7 @@
 	import type { PageData } from './$types'
 
 	const { data }: { data: PageData } = $props()
-	const blog_title = `${PAGES.BLOG.title} - ${AUTHOR.NAME}`
+	const blog_title = app.page_title(PAGES.BLOG.title)
 </script>
 
 <svelte:head>

--- a/src/routes/blog/[slug]/+page.svelte
+++ b/src/routes/blog/[slug]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { external_links } from '$lib/actions/external-links'
-	import { APP, AUTHOR } from '$lib/app'
+	import { APP, app } from '$lib/app'
 	import AdSenseScript from '$lib/components/AdSenseScript.svelte'
 	import DateDisplay from '$lib/components/DateDisplay.svelte'
 	import EngagementButtons from '$lib/components/EngagementButtons.svelte'
@@ -17,7 +17,7 @@
 	const cover_image_source = $derived(blog_images.get_cover_image_url(data.meta.cover_image))
 	const image_url = $derived(cover_image_source ? `${APP.URL}${cover_image_source}` : '')
 	const blog_title = $derived(data.meta.title)
-	const page_title = $derived(`${blog_title} - ${AUTHOR.NAME}`)
+	const page_title = $derived(app.page_title(blog_title))
 </script>
 
 <svelte:head>

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -2,7 +2,7 @@
 	import { afterNavigate } from '$app/navigation'
 	import { chat_api } from '$lib/api/chat-api'
 	import { chat_history } from '$lib/api/chat-history'
-	import { APP, AUTHOR } from '$lib/app'
+	import { APP, app } from '$lib/app'
 	import ChatErrorDetail from '$lib/components/ChatErrorDetail.svelte'
 	import ChatTimestamp from '$lib/components/ChatTimestamp.svelte'
 	import MetaTags from '$lib/components/MetaTags.svelte'
@@ -15,7 +15,7 @@
 	import { scheduling } from '$lib/utils/scheduling'
 	import { fade } from 'svelte/transition'
 
-	const PAGE_TITLE = `${CHAT_LABELS.TITLE} - ${AUTHOR.NAME}`
+	const PAGE_TITLE = app.page_title(CHAT_LABELS.TITLE)
 
 	// Sentinel for "no reply is streaming": the streaming message renders as plain text (see the each
 	// block), every settled message as Markdown.

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { APP, AUTHOR } from '$lib/app'
+	import { APP, app } from '$lib/app'
 	import MetaTags from '$lib/components/MetaTags.svelte'
 	import PageHeader from '$lib/components/PageHeader.svelte'
 	import PageLayout from '$lib/components/PageLayout.svelte'
@@ -12,7 +12,7 @@
 
 	const SOCIAL_LINK_CLASS =
 		'inline-flex items-center gap-3 rounded-lg border border-white/10 bg-slate-800/30 px-4 py-2 text-white/80 transition hover:border-white/30 hover:bg-slate-800/70 hover:text-white'
-	const contact_title = `${PAGES.CONTACT.title} - ${AUTHOR.NAME}`
+	const contact_title = app.page_title(PAGES.CONTACT.title)
 </script>
 
 <svelte:head>

--- a/src/routes/page-title.e2e.ts
+++ b/src/routes/page-title.e2e.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test'
+
+// Every page composes its <title> through app.page_title, so one separator holds site-wide. These pages
+// cover all three call shapes it replaced: a plain script const, a $derived one, and markup that used to
+// build the title inline (#795).
+const TITLED_PAGES = [
+	{ path: '/about', title: 'About' },
+	{ path: '/chat', title: 'AI Chat' },
+	{ path: '/terms', title: 'Terms of Service' },
+] as const
+
+const AUTHOR_NAME = 'Joshua Folkken'
+
+for (const { path, title } of TITLED_PAGES) {
+	test(`${path} titles the page with an em dash separator`, async ({ page }) => {
+		await page.goto(path)
+
+		await expect(page).toHaveTitle(`${title} — ${AUTHOR_NAME}`)
+	})
+}
+
+test('no page falls back to the old hyphen separator', async ({ page }) => {
+	await page.goto('/projects')
+
+	// A hyphen would be indistinguishable from the ones inside project and repo names (game-kit, app-kit).
+	expect(await page.title()).not.toContain(` - ${AUTHOR_NAME}`)
+})

--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	/* eslint-disable max-len */
-	import { APP, AUTHOR, LAST_UPDATED } from '$lib/app'
+	import { APP, app, LAST_UPDATED } from '$lib/app'
 	import PageHeader from '$lib/components/PageHeader.svelte'
 	import PageLayout from '$lib/components/PageLayout.svelte'
 	import PageSection from '$lib/components/PageSection.svelte'
@@ -16,10 +16,11 @@
 	import { PAGES } from '$lib/types/page'
 
 	const last_updated = LAST_UPDATED.PRIVACY_POLICY
+	const page_title = app.page_title(PAGES.PRIVACY_POLICY.title)
 </script>
 
 <svelte:head>
-	<title>{PAGES.PRIVACY_POLICY.title} - {AUTHOR.NAME}</title>
+	<title>{page_title}</title>
 	<meta name="description" content={PAGES.PRIVACY_POLICY.description} />
 </svelte:head>
 

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { APP, AUTHOR } from '$lib/app'
+	import { APP, app } from '$lib/app'
 	import EngagementButtons from '$lib/components/EngagementButtons.svelte'
 	import MetaTags from '$lib/components/MetaTags.svelte'
 	import PageHeader from '$lib/components/PageHeader.svelte'
@@ -9,7 +9,7 @@
 	import { PROJECTS } from '$lib/data/projects'
 	import { PAGES } from '$lib/types/page'
 
-	const title = `${PAGES.PROJECTS.title} - ${AUTHOR.NAME}`
+	const title = app.page_title(PAGES.PROJECTS.title)
 </script>
 
 <svelte:head>

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { external_links } from '$lib/actions/external-links'
-	import { APP, AUTHOR } from '$lib/app'
+	import { APP, app } from '$lib/app'
 	import CardImage from '$lib/components/CardImage.svelte'
 	import EngagementButtons from '$lib/components/EngagementButtons.svelte'
 	import MetaTags from '$lib/components/MetaTags.svelte'
@@ -17,7 +17,7 @@
 	const project = $derived(data.project)
 	const case_study = $derived(data.case_study)
 	const header_page = $derived(project_utilities.get_project_page(project))
-	const page_title = $derived(`${project.title} - ${AUTHOR.NAME}`)
+	const page_title = $derived(app.page_title(project.title))
 	const description = $derived(case_study?.overview ?? project.description)
 	const detail_url = $derived(`${APP.URL}/projects/${data.slug}`)
 	const image_url = $derived(project.image ? `${APP.URL}${project.image}` : undefined)

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	/* eslint-disable max-len */
-	import { APP, AUTHOR, LAST_UPDATED } from '$lib/app'
+	import { APP, app, AUTHOR, LAST_UPDATED } from '$lib/app'
 	import PageHeader from '$lib/components/PageHeader.svelte'
 	import PageLayout from '$lib/components/PageLayout.svelte'
 	import PageSection from '$lib/components/PageSection.svelte'
@@ -9,10 +9,11 @@
 	import { PAGES } from '$lib/types/page'
 
 	const last_updated = LAST_UPDATED.TERMS_OF_SERVICE
+	const page_title = app.page_title(PAGES.TERMS_OF_SERVICE.title)
 </script>
 
 <svelte:head>
-	<title>{PAGES.TERMS_OF_SERVICE.title} - {AUTHOR.NAME}</title>
+	<title>{page_title}</title>
 	<meta name="description" content={PAGES.TERMS_OF_SERVICE.description} />
 </svelte:head>
 


### PR DESCRIPTION
closes #795